### PR TITLE
feat: zsh default

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,9 @@
 	},
 
 	// Set *default* container specific settings.json values on container create.
-	"settings": {},
+	"settings": {
+		"terminal.integrated.shell.linux": "zsh"
+	},
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,8 @@
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
 		"terminal.integrated.shell.linux": "/usr/bin/zsh",
-		"terminal.integrated.defaultProfile.linux": "/usr/bin/zsh"
+		"terminal.integrated.defaultProfile.linux": "/usr/bin/zsh",
+		"terminal.integrated.automationShell.linux": "/usr/bin/zsh"
 	},
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,8 @@
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
-		"terminal.integrated.shell.linux": "zsh"
+		"terminal.integrated.shell.linux": "zsh",
+		"terminal.integrated.defaultProfile.linux": "zsh"
 	},
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,8 +11,8 @@
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
-		"terminal.integrated.shell.linux": "zsh",
-		"terminal.integrated.defaultProfile.linux": "zsh"
+		"terminal.integrated.shell.linux": "/usr/bin/zsh",
+		"terminal.integrated.defaultProfile.linux": "/usr/bin/zsh"
 	},
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- The `.devcontainer.json` configuration now specifies `zsh` as the default shell for the integrated terminal in Linux, enhancing the development environment setup.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>devcontainer.json</strong><dd><code>Set Default Shell to Zsh in Dev Container</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
.devcontainer/devcontainer.json

<li>Set <code>terminal.integrated.shell.linux</code> to <code>zsh</code> in the container settings.<br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/codespaces/pull/50/files#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

