### PR TITLE
feat: bashrc calls zsh

### DIFF
--- a/.devcontainer/tools/add-tools-to-shells.sh
+++ b/.devcontainer/tools/add-tools-to-shells.sh
@@ -4,6 +4,7 @@ add_tools_to_shells() {
     if [ -f "/home/vscode/.bashrc" ]; then
         find /etc/tools/ -type f ! -name "add-tools-to-shells.sh" ! -name "helm-repositories.yaml" \
             -exec sh -c 'echo >> /home/vscode/.bashrc; cat "{}" >> /home/vscode/.bashrc' \;
+        echo "zsh" >> /home/vscode/.bashrc
     fi
 
     if [ -d "/home/vscode/.oh-my-zsh/custom" ]; then


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- This PR enhances the developer container setup by modifying `.bashrc` to automatically call `zsh` at the end. This ensures a seamless transition to `zsh` for users working in environments where `.bashrc` is the initial shell configuration file loaded.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>add-tools-to-shells.sh</strong><dd><code>Enhance .bashrc to Automatically Call zsh</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
.devcontainer/tools/add-tools-to-shells.sh

<li>Adds a command to <code>.bashrc</code> to call <code>zsh</code> at the end, ensuring that <code>zsh</code> is <br>executed after <code>.bashrc</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/codespaces/pull/51/files#diff-596a4e7d6987e10ef0249eac63bcecc96646981c9278ff61b5b3effc03419e09">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

