### PR TITLE
major: remove default of zsh from bash

### DIFF
--- a/.devcontainer/tools/add-tools-to-shells.sh
+++ b/.devcontainer/tools/add-tools-to-shells.sh
@@ -4,7 +4,6 @@ add_tools_to_shells() {
     if [ -f "/home/vscode/.bashrc" ]; then
         find /etc/tools/ -type f ! -name "add-tools-to-shells.sh" ! -name "helm-repositories.yaml" \
             -exec sh -c 'echo >> /home/vscode/.bashrc; cat "{}" >> /home/vscode/.bashrc' \;
-        echo "zsh" >> /home/vscode/.bashrc
     fi
 
     if [ -d "/home/vscode/.oh-my-zsh/custom" ]; then

--- a/.devcontainer/tools/create-ghcr-regcred.sh
+++ b/.devcontainer/tools/create-ghcr-regcred.sh
@@ -40,7 +40,6 @@ create-ghcr-regcred() {
         return
     fi
 
-    set -e
     b64_enc_regcred=$(echo -n "$gh_username:$gh_token" | base64)
 
     echo "{\"auths\":{\"ghcr.io\":{\"auth\":\"$b64_enc_regcred\"}}}"


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Removed the default addition of `zsh` to `.bashrc` in the `add-tools-to-shells.sh` script.
- Simplified the script by eliminating an unnecessary line.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>add-tools-to-shells.sh</strong><dd><code>Remove default addition of `zsh` to `.bashrc`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
.devcontainer/tools/add-tools-to-shells.sh

<li>Removed the addition of <code>zsh</code> to <code>.bashrc</code>.<br> <li> Simplified the script by eliminating unnecessary line.<br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/codespaces/pull/111/files#diff-596a4e7d6987e10ef0249eac63bcecc96646981c9278ff61b5b3effc03419e09">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

