### PR TITLE
fix: changing uid of vscode user to 1337 to be compatible with other …

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -102,7 +102,8 @@ RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor 
     && tar -xf vscode_cli.tar.gz \
     && rm vscode_cli.tar.gz
 
-
+#AWS Debian has a user of admin that uses the UID of 1000. THis is to try and fix that. We are also using UID of 1337 on the system/host level here: https://github.com/GlueOps/development-only-utilities/blob/main/tools/developer-setup/linux-setup.sh#L8
+RUN usermod --uid 1337 vscode
 
 ARG NONROOT_USER=vscode
 RUN echo "#!/bin/sh\n\


### PR DESCRIPTION
### **User description**
…clouds


___

### **PR Type**
bug_fix


___

### **Description**
- Changed the UID of the `vscode` user to 1337 in the Dockerfile to ensure compatibility with AWS Debian systems, where the UID 1000 is already in use by the `admin` user.
- Added a comment in the Dockerfile to explain the reason for the UID change and provide a reference to the related setup script.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Change UID of vscode user to 1337 for compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/Dockerfile

<li>Added a comment explaining the UID change for compatibility with AWS <br>Debian.<br> <li> Changed the UID of the <code>vscode</code> user to 1337 using the <code>usermod</code> command.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/codespaces/pull/147/files#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information