### PR TITLE
feat: adding packer (1.11.2)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,6 +22,7 @@ ARG VERSION_HELM_DIFF=3.9.10
 ARG VERSION_CHARM_GUM=0.14.5
 ARG VERSION_ARGO_CD_CLI=2.10.17
 ARG VERSION_K3D=5.7.4
+ARG VERSION_HASHICORP_PACKER=1.11.2
 
 # https://developer.hashicorp.com/vault/docs/commands#vault_skip_verify
 # https://github.com/GlueOps/terraform-module-kubernetes-hashicorp-vault-configuration/wiki
@@ -89,6 +90,11 @@ RUN curl -Lo ./gum_${VERSION_CHARM_GUM}_Linux_x86_64.tar.gz https://github.com/c
 RUN curl -sSL -o argocd-linux-amd64 https://github.com/argoproj/argo-cd/releases/download/v${VERSION_ARGO_CD_CLI}/argocd-linux-amd64 \
     && sudo install -m 555 argocd-linux-amd64 /usr/local/bin/argocd \
     && rm argocd-linux-amd64
+RUN wget "https://releases.hashicorp.com/packer/${VERSION_HASHICORP_PACKER}/packer_${VERSION_HASHICORP_PACKER}_linux_amd64.zip" \
+    && unzip packer_${VERSION_HASHICORP_PACKER}_linux_amd64.zip \
+    && mv packer /usr/local/bin \
+    && rm packer_${VERSION_HASHICORP_PACKER}_linux_amd64.zip \
+    && rm LICENSE.txt
 
 # Install code tunnel so we can run outside of github codespaces easily
 RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > packages.microsoft.gpg \


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added HashiCorp Packer version 1.11.2 to the development container.
- Updated the Dockerfile to include steps for downloading and installing Packer.
- Ensured Packer binary is moved to `/usr/local/bin` for accessibility.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Add HashiCorp Packer installation to Dockerfile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/Dockerfile

<li>Added a new argument <code>VERSION_HASHICORP_PACKER</code> with version 1.11.2.<br> <li> Introduced installation steps for HashiCorp Packer.<br> <li> Downloaded and installed Packer binary to <code>/usr/local/bin</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/codespaces/pull/155/files#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information