### PR TITLE
major: make AWS AMI's publicly accessible across ALL aws accounts.

### DIFF
--- a/aws.pkr.hcl
+++ b/aws.pkr.hcl
@@ -14,6 +14,7 @@ source "amazon-ebs" "cde" {
     owners      = ["136693071363"] # Amazon
     most_recent = true
   }
+  ami_groups    = ["all"]
   instance_type = "t3a.large"
   ssh_username  = "admin"
   launch_block_device_mappings {


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added the `ami_groups` parameter with the value `["all"]` to the AWS Packer configuration file (`aws.pkr.hcl`).
- This change makes the Amazon Machine Image (AMI) publicly accessible across all AWS accounts.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aws.pkr.hcl</strong><dd><code>Make AWS AMI publicly accessible to all accounts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aws.pkr.hcl

<li>Added <code>ami_groups</code> parameter to make AMI publicly accessible.<br> <li> Ensures AMI is accessible across all AWS accounts.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/codespaces/pull/157/files#diff-9ab07ad01fa33f081368c9c989bad8b7b7c39a7c33fa7d1a827289763fdd4bd7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information