### PR TITLE
feat: restrict to codespaces runner

### DIFF
--- a/.github/workflows/packer-qemu.yml
+++ b/.github/workflows/packer-qemu.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: codespaces
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Updated the GitHub Actions workflow to run on the `codespaces` runner instead of `ubuntu-latest`.
- This change restricts the workflow execution environment to Codespaces, aligning with the intended development setup.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>packer-qemu.yml</strong><dd><code>Restrict GitHub Actions workflow to Codespaces runner</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/packer-qemu.yml

- Changed the runner from `ubuntu-latest` to `codespaces`.



</details>


  </td>
  <td><a href="https://github.com/GlueOps/codespaces/pull/164/files#diff-ca15d765f559455a2ffe5a6b3e325e09e8020dade3803e4bb5517c3bf8328fe1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information