### PR TITLE
fix: add missing comma

### DIFF
--- a/qemu.pkr.hcl
+++ b/qemu.pkr.hcl
@@ -61,7 +61,7 @@ build {
       "rm ci-data.iso",
       "rm user-data",
       "rm meta-data",
-      "rm images/${var.glueops_codespaces_container_tag}.qcow2"
+      "rm images/${var.glueops_codespaces_container_tag}.qcow2",
       "mv images/${var.glueops_codespaces_container_tag}-compressed.qcow2 images/${var.glueops_codespaces_container_tag}.qcow2"
     ]
   }


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fixed a syntax error by adding a missing comma in the `inline` array of the `post-processor` block in the `qemu.pkr.hcl` file.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>qemu.pkr.hcl</strong><dd><code>Fix missing comma in post-processor inline array</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

qemu.pkr.hcl

<li>Added a missing comma in the <code>inline</code> array of the <code>post-processor</code> block.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/codespaces/pull/165/files#diff-30785380889900a3ff0f31688752b04652db74dd67fa7e44f0b74e9efe39e38b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information