### PR TITLE
fix: newline issue with create-ghcr-regcred

### DIFF
--- a/.devcontainer/tools/create-ghcr-regcred.sh
+++ b/.devcontainer/tools/create-ghcr-regcred.sh
@@ -42,6 +42,6 @@ if [[ -z $gh_username || -z $gh_token ]]; then
 fi
 
 set -e
-b64_enc_regcred=$(echo -n "$gh_username:$gh_token" | base64)
+b64_enc_regcred=$(echo -n "$gh_username:$gh_token" | base64 -w0)
 
-echo "{\"auths\":{\"ghcr.io\":{\"auth\":\"$b64_enc_regcred\"}}}"
+echo -n "{\"auths\":{\"ghcr.io\":{\"auth\":\"$b64_enc_regcred\"}}}"


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fixed a newline issue in the `create-ghcr-regcred.sh` script by ensuring the base64 encoding does not include line breaks.
- Modified the script to output JSON without a trailing newline, ensuring compatibility with systems expecting a single-line JSON string.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create-ghcr-regcred.sh</strong><dd><code>Fix newline issue in GHCR credential creation script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/tools/create-ghcr-regcred.sh

<li>Fixed newline issue by using <code>base64 -w0</code> for encoding.<br> <li> Modified output to avoid trailing newline with <code>echo -n</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/codespaces/pull/204/files#diff-525f5f05ffced4e119fe42e2a271b70445a3415eb1b4c69b97962aa4c66d888f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information