### PR TITLE
feat: trigger image cache at the end of the qmeu job

### DIFF
--- a/.github/workflows/packer-qemu.yml
+++ b/.github/workflows/packer-qemu.yml
@@ -67,5 +67,10 @@ jobs:
         with:
           file: "*.qcow2.tar.part_*"
           tag_name: ${{ inputs.glueops_codespace_tag || github.event.workflow_run.head_branch }}
+
+      - name: Trigger image cache
+        run: |
+          curl 'https://api-provisioner.glueopshosted.rocks/update-image-cache' || true
+          curl 'https://api-provisioner.glueopshosted.com/update-image-cache' || true
           
           


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added a step to trigger image cache update in the QEMU job workflow.

- Ensured fallback mechanism with two API endpoints for cache update.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>packer-qemu.yml</strong><dd><code>Add image cache update step to workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/packer-qemu.yml

<li>Added a new step to trigger image cache update.<br> <li> Included two API endpoints for redundancy.<br> <li> Ensured the step runs without failing the workflow.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/codespaces/pull/228/files#diff-ca15d765f559455a2ffe5a6b3e325e09e8020dade3803e4bb5517c3bf8328fe1">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information