### PR TITLE
chore: update docs with some caveats around releasing/testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ python --version
 - Please stick to semver standards when dropping a new tag.
 - Once you publish a release a new image will be built and uploaded to GHCR.io: https://github.com/GlueOps/codespaces/pkgs/container/codespaces
 
+**Note:** Due to the connection between the packer workflows and the Docker build/publish workflow, it's not possible to cut a release from any branch other than `main`. Some limitations in GitHub prevent the actions checkout step in the packer workflows from accurately determining the parent commit SHA, which defaults to `main`. Therefore, if you're testing changes outside of the Dockerfile, this method may not provide accurate results. One potential solution is to combine all the workflows, but this would result in a runtime of an hour or more.
+
 
 
 # Running packer locally:


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Added a note about limitations in releasing/testing from non-main branches.

- Explained GitHub actions checkout step limitations in packer workflows.

- Suggested a potential solution for workflow limitations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document limitations and solutions for releasing/testing workflows</code></dd></summary>
<hr>

README.md

<li>Added a note about branch limitations for releases.<br> <li> Explained issues with GitHub actions determining parent commit SHA.<br> <li> Suggested combining workflows as a potential solution.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/codespaces/pull/238/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>