### PR TITLE
fix: pinning devbox version to 0.13.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -143,6 +143,8 @@ RUN code --install-extension MS-vsliveshare.vsliveshare --extensions-dir /home/v
 RUN code --install-extension GitHub.codespaces --extensions-dir /home/vscode/.vscode-remote/extensions
 
 RUN curl -L https://nixos.org/nix/install | bash -s -- --no-daemon
+# 0.14.0 came out a couple weeks ago and it appears to be problematic. So pinning and manually upgrading seems like a good option
+ENV DEVBOX_USE_VERSION=0.13.0
 RUN curl -fsSL https://get.jetify.com/devbox | bash -s -- -f
 
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Configuration changes


___

### **Description**
- Pinned the `devbox` version to 0.13.0 to avoid issues with newer versions.

- Added an environment variable `DEVBOX_USE_VERSION` for version control.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Pin `devbox` version and add environment variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/Dockerfile

<li>Added <code>DEVBOX_USE_VERSION</code> environment variable set to 0.13.0.<br> <li> Commented on issues with <code>devbox</code> version 0.14.0.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/codespaces/pull/251/files#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>