### PR TITLE
fix: remove aws cli from qemu workflow

### DIFF
--- a/.github/workflows/packer-qemu.yml
+++ b/.github/workflows/packer-qemu.yml
@@ -48,13 +48,6 @@ jobs:
         id: build
         run: packer build -var glueops_codespaces_container_tag=${{ inputs.glueops_codespace_tag || github.event.workflow_run.head_branch }} qemu.pkr.hcl
 
-      - id: install-aws-cli
-        uses: unfor19/install-aws-cli-action@v1
-        with:
-          version: 2
-          verbose: false
-          arch: amd64 
-
       - name: Split qcow2 image into 1024M files
         run: |
            mv images/${{ inputs.glueops_codespace_tag || github.event.workflow_run.head_branch }}.qcow2 .


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Removed AWS CLI installation step from QEMU workflow.

- Simplified the workflow by eliminating unnecessary dependencies.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>packer-qemu.yml</strong><dd><code>Removed AWS CLI installation from QEMU workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/packer-qemu.yml

<li>Removed the step to install AWS CLI.<br> <li> Simplified the workflow by removing unused dependencies.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/codespaces/pull/259/files#diff-ca15d765f559455a2ffe5a6b3e325e09e8020dade3803e4bb5517c3bf8328fe1">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>