### PR TITLE
fix: change hardcoded password to rand generate a temp one

### DIFF
--- a/.github/workflows/packer-qemu.yml
+++ b/.github/workflows/packer-qemu.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Run packer build
         id: build
-        run: packer build -var glueops_codespaces_container_tag=${{ inputs.glueops_codespace_tag || github.event.workflow_run.head_branch }} -var image_password=${{ IMAGE_PASSWORD }} qemu.pkr.hcl
+        run: packer build -var glueops_codespaces_container_tag=${{ inputs.glueops_codespace_tag || github.event.workflow_run.head_branch }} -var image_password=${{ env.IMAGE_PASSWORD }} qemu.pkr.hcl
 
       - name: Split qcow2 image into 1024M files
         run: |

--- a/.github/workflows/packer-qemu.yml
+++ b/.github/workflows/packer-qemu.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           version: 1.11.2
 
+      - name: Generate image password
+        run: echo "IMAGE_PASSWORD=$(openssl rand -base64 16)" >> $GITHUB_ENV
+
       - name: Generate cloud-init iso
         run: |
           sudo apt install genisoimage
@@ -31,7 +34,7 @@ jobs:
           chpasswd:
             expire: False
             users:
-            - {name: debian, password: password, type: text}
+            - {name: debian, password: '"$IMAGE_PASSWORD"', type: text}
           ssh_pwauth: True' > user-data
           echo 'instance-id: iid-local01
           local-hostname: localhost' > meta-data
@@ -46,7 +49,7 @@ jobs:
 
       - name: Run packer build
         id: build
-        run: packer build -var glueops_codespaces_container_tag=${{ inputs.glueops_codespace_tag || github.event.workflow_run.head_branch }} qemu.pkr.hcl
+        run: packer build -var glueops_codespaces_container_tag=${{ inputs.glueops_codespace_tag || github.event.workflow_run.head_branch }} -var image_password=${{ IMAGE_PASSWORD }} qemu.pkr.hcl
 
       - name: Split qcow2 image into 1024M files
         run: |

--- a/qemu.pkr.hcl
+++ b/qemu.pkr.hcl
@@ -2,6 +2,10 @@ variable "glueops_codespaces_container_tag" {
   type    = string
 }
 
+variable "image_password" {
+  type    = string
+}
+
 source "qemu" "qemu-amd64" {
   iso_url           = "https://cloud.debian.org/images/cloud/bookworm/20241004-1890/debian-12-generic-amd64-20241004-1890.qcow2"
   iso_checksum      = "file:https://cloud.debian.org/images/cloud/bookworm/20241004-1890/SHA512SUMS"
@@ -11,7 +15,7 @@ source "qemu" "qemu-amd64" {
   format            = "qcow2"
   vm_name           = "${var.glueops_codespaces_container_tag}.qcow2"
   ssh_username      = "debian"
-  ssh_password      = "password"
+  ssh_password      = "${var.image_password}"
   shutdown_command  = "echo 'packer' | sudo -S shutdown -P now"
   headless          = true
   ssh_wait_timeout  = "5m"


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Replaced hardcoded password with dynamically generated one.

- Added `image_password` variable in `qemu.pkr.hcl`.

- Updated GitHub Actions workflow to generate and use a secure password.

- Enhanced security by integrating dynamic password generation in cloud-init.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>qemu.pkr.hcl</strong><dd><code>Introduced dynamic password variable for SSH</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

qemu.pkr.hcl

<li>Added a new variable <code>image_password</code> for dynamic password assignment.<br> <li> Replaced hardcoded SSH password with the <code>image_password</code> variable.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/codespaces/pull/264/files#diff-30785380889900a3ff0f31688752b04652db74dd67fa7e44f0b74e9efe39e38b">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>packer-qemu.yml</strong><dd><code>Integrated dynamic password generation in workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/packer-qemu.yml

<li>Added a step to generate a secure password using OpenSSL.<br> <li> Updated cloud-init configuration to use the generated password.<br> <li> Passed the generated password to the Packer build command.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/codespaces/pull/264/files#diff-ca15d765f559455a2ffe5a6b3e325e09e8020dade3803e4bb5517c3bf8328fe1">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>