### PR TITLE
feat: set dev command to use provisioner api

### DIFF
--- a/developer-setup.sh
+++ b/developer-setup.sh
@@ -42,7 +42,7 @@ dev() {
             tmux attach-session -t dev
         fi
     fi
-    echo "Fetching the last 10 tags..."
+    echo "Fetching the last 5 tags..."
     if [ "${ENVIRONMENT:-prod}" = "nonprod" ]; then
         echo "WARNING: RUNNING IN NONPROD ENVIRONMENT"
         IFS=$'\n' tags=($(curl -s https://api-provisioner.glueopshosted.rocks/v1/get-images | jq -r '.images[]' | head -5))

--- a/developer-setup.sh
+++ b/developer-setup.sh
@@ -43,7 +43,12 @@ dev() {
         fi
     fi
     echo "Fetching the last 10 tags..."
-    IFS=$'\n' tags=($(curl -s https://api.github.com/repos/GlueOps/codespaces/tags | jq -r '.[].name' | head -10))
+    if [ "${ENVIRONMENT:-prod}" = "nonprod" ]; then
+        echo "WARNING: RUNNING IN NONPROD ENVIRONMENT"
+        IFS=$'\n' tags=($(curl -s https://api-provisioner.glueopshosted.rocks/v1/get-images | jq -r '.images[]' | head -5))
+    else
+        IFS=$'\n' tags=($(curl -s https://api-provisioner.glueopshosted.com/v1/get-images | jq -r '.images[]' | head -5))
+    fi
 
     # Check for cached images
     cached_images=$(sudo docker images --format "{{.Repository}}:{{.Tag}}" | grep "ghcr.io/glueops/codespaces")


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Updated `dev` command to use provisioner API.

- Added environment-based logic for fetching image tags.

- Introduced warning for non-production environment usage.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>developer-setup.sh</strong><dd><code>Enhance `dev` function with provisioner API integration</code>&nbsp; &nbsp; </dd></summary>
<hr>

developer-setup.sh

<li>Updated <code>dev</code> function to fetch image tags from provisioner API.<br> <li> Added conditional logic for non-production and production <br>environments.<br> <li> Displayed a warning when running in a non-production environment.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/codespaces/pull/276/files#diff-935e77d8a09f6b81dc8897c83ed83ce04e4a30f07e06587600390cfb7c538ac9">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>