### PR TITLE
feat: adding a dev shortcut to use when logging in as root instead of vscode user

### DIFF
--- a/developer-setup.sh
+++ b/developer-setup.sh
@@ -85,8 +85,22 @@ dev() {
 }
 
 GLUEOPSRC="$(declare -f dev)"
-
 echo "$GLUEOPSRC" | sudo tee -a /home/vscode/.glueopsrc
+
+
+dev() {
+    if [ "$(whoami)" != "vscode" ]; then
+        echo -e "\033[1;31m⚠️  You are not the 'vscode' user. Switching to 'vscode' and running 'dev' \033[0m"
+        exec su - vscode -c "bash -i -c dev"
+    else
+        echo "You are already the 'vscode' user."
+    fi
+}
+
+ROOTBASHRC="$(declare -f dev)"
+echo "$ROOTBASHRC" | sudo tee -a /root/.bashrc
+
+
 
 echo "source /home/vscode/.glueopsrc" | sudo tee -a /home/vscode/.bashrc
 sudo chown -R vscode:vscode /home/vscode


### PR DESCRIPTION
### **User description**
When logging is as the root user we generally have to switch to the vscode user. Instead there is also a "dev" command that will do the switch for you and then start the normal dev command that prompts for a codespace selection. This is what it looks like:


https://github.com/user-attachments/assets/29904e2c-3b50-4440-bb31-333cae834d8c


___

### **PR Type**
Enhancement


___

### **Description**
- Added a `dev` shortcut for root user to switch to `vscode` user.

- Updated `.bashrc` for root user to include the `dev` function.

- Ensured `dev` function checks the current user before execution.

- Improved user experience with informative messages during user switch.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>developer-setup.sh</strong><dd><code>Introduced `dev` function for user switching and setup</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

developer-setup.sh

<li>Added a <code>dev</code> function to handle user switching.<br> <li> Appended the <code>dev</code> function to root's <code>.bashrc</code>.<br> <li> Included user validation and informative messages in the <code>dev</code> function.<br> <li> Adjusted <code>.bashrc</code> for <code>vscode</code> user to source <code>.glueopsrc</code>.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/codespaces/pull/282/files#diff-935e77d8a09f6b81dc8897c83ed83ce04e4a30f07e06587600390cfb7c538ac9">+15/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>