### PR TITLE
feat: when launching code tunnel it switches the tmux session to read only which should prevent interruptions like ctrl + c from the user

### DIFF
--- a/developer-setup.sh
+++ b/developer-setup.sh
@@ -285,7 +285,7 @@ dev() {
 
     gum style --border normal --border-foreground=240 --padding "0 2" --margin "1 0" \
         "🚀 Executing 'code tunnel' inside the container..."
-
+    tmux switch-client -r
     sudo docker exec -it "$CONTAINER_NAME" bash -c "code tunnel --random-name $LOG_OPTIONS"
 
     local exec_status=$?


### PR DESCRIPTION
### **User description**
feat: when launching code tunnel it switches the tmuxh session to read only which should prevent interruptions like ctrl + c from the user. The user should be able to safely close out tailscale or hit other keys without interruption the code tunnel. If the user relaunches the tailscale session and then runs `dev` they will get a read/write terminal. In the event they run `dev` and a code tunnel is already running they will have the ability to break things like before.


___

### **PR Type**
Enhancement


___

### **Description**
- Switch tmux session to read-only before launching code tunnel

- Prevent user interruptions (e.g., Ctrl+C) during code tunnel execution

- Ensure safer code tunnel operation within the container


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>developer-setup.sh</strong><dd><code>Set tmux session to read-only before code tunnel launch</code>&nbsp; &nbsp; </dd></summary>
<hr>

developer-setup.sh

<li>Added <code>tmux switch-client -r</code> before running code tunnel<br> <li> Ensures tmux session is set to read-only during code tunnel execution<br> <li> Aims to prevent user interruptions like Ctrl+C


</details>


  </td>
  <td><a href="https://github.com/GlueOps/codespaces/pull/291/files#diff-935e77d8a09f6b81dc8897c83ed83ce04e4a30f07e06587600390cfb7c538ac9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>