### PR TITLE
Fix/workflows (#308)

### DIFF
--- a/.github/workflows/build_and_publish_devcontainer.yml
+++ b/.github/workflows/build_and_publish_devcontainer.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: codespaces
     steps:
 
       - name: Checkout (GitHub)

--- a/.github/workflows/packer-aws.yml
+++ b/.github/workflows/packer-aws.yml
@@ -16,7 +16,18 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Debug Print Ref Info
+        run: |
+          echo "inputs.glueops_codespace_tag: ${{ inputs.glueops_codespace_tag }}"
+          echo "event.workflow_run.head_branch: ${{ github.event.workflow_run.head_branch }}"
+          echo "event.workflow_run.head_sha: ${{ github.event.workflow_run.head_sha }}"
+          echo "github.ref: ${{ github.ref }}"
+          echo "event_name: ${{ github.event_name }}"
+          
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.glueops_codespace_tag || github.event.workflow_run.head_sha }}
 
       - name: Setup `packer`
         uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75b232 # v3.1.0

--- a/.github/workflows/packer-qemu.yml
+++ b/.github/workflows/packer-qemu.yml
@@ -16,7 +16,18 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: codespaces
     steps:
+      - name: Debug Print Ref Info
+        run: |
+          echo "inputs.glueops_codespace_tag: ${{ inputs.glueops_codespace_tag }}"
+          echo "event.workflow_run.head_branch: ${{ github.event.workflow_run.head_branch }}"
+          echo "event.workflow_run.head_sha: ${{ github.event.workflow_run.head_sha }}"
+          echo "github.ref: ${{ github.ref }}"
+          echo "event_name: ${{ github.event_name }}"
+          
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.glueops_codespace_tag || github.event.workflow_run.head_sha }}
 
       - name: Setup packer
         uses: hashicorp/setup-packer@1aa358be5cf73883762b302a3a03abd66e75b232 # v3.1.0


### PR DESCRIPTION
### **User description**
* fix: gha to support builds not on main

* fix: gha to support builds not on main

* feat: update container image build to use codespaces runner


___

### **PR Type**
enhancement


___

### **Description**
- Update GitHub Actions to support builds on non-main branches
  - Add debug steps for branch and ref info in workflows
  - Improve checkout step to fetch correct refs and full history

- Change runner to `codespaces` for devcontainer and packer-qemu builds


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build_and_publish_devcontainer.yml</strong><dd><code>Use Codespaces runner for devcontainer build workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build_and_publish_devcontainer.yml

- Change runner from `ubuntu-latest` to `codespaces`


</details>


  </td>
  <td><a href="https://github.com/GlueOps/codespaces/pull/309/files#diff-3f789d583695e1fb3d10909fe659644a618a199d84804c087de7bc11d9f69622">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>packer-aws.yml</strong><dd><code>Improve AWS packer workflow with debug and ref handling</code>&nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/packer-aws.yml

<li>Add debug step to print ref and event info<br> <li> Update checkout to fetch full history and use correct ref


</details>


  </td>
  <td><a href="https://github.com/GlueOps/codespaces/pull/309/files#diff-8a91b2b2e6e7448b50d6598c23bab5aa6eae4a8ef7fcf965a93c20d0c20e5724">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>packer-qemu.yml</strong><dd><code>Enhance QEMU packer workflow with debug and ref handling</code>&nbsp; </dd></summary>
<hr>

.github/workflows/packer-qemu.yml

<li>Add debug step to print ref and event info<br> <li> Update checkout to fetch full history and use correct ref


</details>


  </td>
  <td><a href="https://github.com/GlueOps/codespaces/pull/309/files#diff-ca15d765f559455a2ffe5a6b3e325e09e8020dade3803e4bb5517c3bf8328fe1">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>