### PR TITLE
fix: revert runs-on node for container image build

### DIFF
--- a/.github/workflows/build_and_publish_devcontainer.yml
+++ b/.github/workflows/build_and_publish_devcontainer.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: codespaces
+    runs-on: ubuntu-latest
     steps:
 
       - name: Checkout (GitHub)


### PR DESCRIPTION
### **PR Type**
bug_fix, enhancement


___

### **Description**
- Change GitHub Actions runner from `codespaces` to `ubuntu-latest`

- Ensure compatibility and stability for container image build workflow


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build_and_publish_devcontainer.yml</strong><dd><code>Update workflow runner to `ubuntu-latest`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build_and_publish_devcontainer.yml

<li>Changed <code>runs-on</code> from <code>codespaces</code> to <code>ubuntu-latest</code><br> <li> Affects the environment used for building and publishing dev <br>containers


</details>


  </td>
  <td><a href="https://github.com/GlueOps/codespaces/pull/310/files#diff-3f789d583695e1fb3d10909fe659644a618a199d84804c087de7bc11d9f69622">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>