### PR TITLE
feat: update debian image to always uses latest of debian 12/bookworm

### DIFF
--- a/qemu.pkr.hcl
+++ b/qemu.pkr.hcl
@@ -7,8 +7,8 @@ variable "image_password" {
 }
 
 source "qemu" "qemu-amd64" {
-  iso_url           = "https://cloud.debian.org/images/cloud/bookworm/20241004-1890/debian-12-generic-amd64-20241004-1890.qcow2"
-  iso_checksum      = "file:https://cloud.debian.org/images/cloud/bookworm/20241004-1890/SHA512SUMS"
+  iso_url           = "https://cloud.debian.org/images/cloud/bookworm/daily/latest/debian-12-generic-amd64-daily.qcow2"
+  iso_checksum      = "file:https://cloud.debian.org/images/cloud/bookworm/daily/latest/SHA512SUMS"
   disk_image        = true
   output_directory  = "images"
   disk_size         = 10000


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Update Debian 12 image source to use daily latest builds

- Replace fixed date version with dynamic latest version


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Fixed Date Image"] --> B["Daily Latest Image"]
  B --> C["Always Current Debian 12"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>qemu.pkr.hcl</strong><dd><code>Switch to daily latest Debian images</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

qemu.pkr.hcl

<li>Updated <code>iso_url</code> from fixed date version to daily latest<br> <li> Updated <code>iso_checksum</code> URL to match latest daily builds


</details>


  </td>
  <td><a href="https://github.com/GlueOps/codespaces/pull/327/files#diff-30785380889900a3ff0f31688752b04652db74dd67fa7e44f0b74e9efe39e38b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>