### PR TITLE
fix: nodepool get version from the kubernetes main version

### DIFF
--- a/.devcontainer/tools/script_captain_utils
+++ b/.devcontainer/tools/script_captain_utils
@@ -32,11 +32,12 @@ def write_file(filepath:str,lines:list[str]):
         for i in lines:
             f.write(i)
 
-def copy_lines(lines:list[str],start:int,end:int,ami_version:Optional[str]):
+def copy_lines(lines:list[str],start:int,end:int,ami_version:Optional[str],current_kubernetes_version:str):
     new_lines = []
     for line in lines[start:end]:
         name_match = re.match(r'^\s*#?\s*"name"\s*:\s*"([^"]+)', line)
         ami_match = re.match(r'^\s*"ami_release_version"\s*:\s*"([^"]+)"', line)
+        kubernetes_version_match = re.match(r'^\s*#?\s*"kubernetes_version"\s*:\s*"(\d+\.\d+)"', line)
         if name_match:
             name = name_match.group()
             index = int(name.split("-")[-1])
@@ -44,12 +45,15 @@ def copy_lines(lines:list[str],start:int,end:int,ami_version:Optional[str]):
         if ami_match and ami_version:
             ami = ami_match.group(1) 
             line = line.replace(ami,ami_version)
+        if kubernetes_version_match:
+            nodepool_kubernetes_version = kubernetes_version_match.group(1)
+            line = line.replace(nodepool_kubernetes_version,current_kubernetes_version)
         new_lines.append(line)
     return new_lines
 
-def add_new_node_pool(lines:list[str], start:int,end:int,ami_release_version:Optional[str]):
+def add_new_node_pool(lines:list[str], start:int,end:int,ami_release_version:Optional[str],current_kubernetes_version:str):
     print("upgrading nodepool")
-    copied_lines = copy_lines(lines,start,end,ami_release_version)
+    copied_lines = copy_lines(lines,start,end,ami_release_version,current_kubernetes_version)
     lines[end-1] = lines[end-1].replace("}","},")
     new_lines = lines[:end] + copied_lines + lines[end:]
     return new_lines
@@ -347,10 +351,11 @@ if args.upgrade_addons:
 
 if args.upgrade_ami_version:
     versions = find_ami_version(versions_filepath,lines)
-    lines = add_new_node_pool(lines,start,end,versions['ami_release_version']['target'])
+    kubernetes_version = find_kubernetes_version(versions_filepath)
+    lines = add_new_node_pool(lines,start,end,versions['ami_release_version']['target'],kubernetes_version['eks_version']['current'])
 
 if args.upgrade_kubernetes_version:
-    version = find_kubernetes_version(versions_filepath,lines)
+    version = find_kubernetes_version(versions_filepath)
     print(f"we're upgrading to {version}")
     lines = upgrade_kubernetes_version(lines,version['eks_version']['target'])
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix nodepool Kubernetes version synchronization with main cluster

- Update version extraction logic for consistency

- Modify function signatures to pass version parameters


___

### **Changes diagram**

```mermaid
flowchart LR
  A["find_kubernetes_version"] --> B["extract current version"]
  B --> C["copy_lines function"]
  C --> D["update nodepool kubernetes_version"]
  D --> E["add_new_node_pool"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>script_captain_utils</strong><dd><code>Sync nodepool Kubernetes version with cluster</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/tools/script_captain_utils

<li>Add <code>current_kubernetes_version</code> parameter to <code>copy_lines</code> and <br><code>add_new_node_pool</code> functions<br> <li> Add regex matching for <code>kubernetes_version</code> field in nodepool <br>configuration<br> <li> Update version replacement logic to sync nodepool version with main <br>cluster<br> <li> Modify function calls to pass Kubernetes version from main cluster


</details>


  </td>
  <td><a href="https://github.com/GlueOps/codespaces/pull/328/files#diff-eeccb87978ae5bde18f05503dcfe73c09ad59c508778400fc3047d038f1c04c2">+10/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>