### PR TITLE
feat: add another section to inspect pods non-running status

### DIFF
--- a/.devcontainer/tools/captain_utils.sh
+++ b/.devcontainer/tools/captain_utils.sh
@@ -217,14 +217,18 @@ handle_aws_options() {
     if [ "$aws_component" = "upgrade-kubernetes" ]; then
         handle_kubernetes_version
     fi
-
    
+}
+
+handle_inspect_pods() {
+    gum style --bold --foreground 212 "Inspecting pods in the cluster"
+    kubectl get pods --watch -A | grep "Pending\|CrashLoopBackOff\|Error\|ContainerCreating\|ImagePullBackOff\"
 }
 
 show_production(){
     while true; do
-        component=$(gum choose "show_diff_table" "argocd" "glueops-platform" "aws" "Exit")
-        
+        component=$(gum choose "show_diff_table" "argocd" "glueops-platform" "aws" "inspect_pods" "Exit")
+
         # Handle exit option
         if [ "$component" = "Exit" ]; then
             echo "Goodbye!"
@@ -248,6 +252,9 @@ show_production(){
             handle_argocd
         fi
         
+        if [ "$component" = "inspect_pods" ]; then
+            handle_inspect_pods
+        fi
        
     done
 }

--- a/.devcontainer/tools/captain_utils.sh
+++ b/.devcontainer/tools/captain_utils.sh
@@ -222,7 +222,7 @@ handle_aws_options() {
 
 handle_inspect_pods() {
     gum style --bold --foreground 212 "Inspecting pods in the cluster"
-    kubectl get pods --watch -A | grep "Pending\|CrashLoopBackOff\|Error\|ContainerCreating\|ImagePullBackOff\"
+    watch -n 2 'kubectl get pods -A | grep "Pending\|CrashLoopBackOff\|Error\|ContainerCreating\|ImagePullBackOff\|ErrImagePull" || true'
 }
 
 show_production(){

--- a/.devcontainer/tools/captain_utils.sh
+++ b/.devcontainer/tools/captain_utils.sh
@@ -222,7 +222,7 @@ handle_aws_options() {
 
 handle_inspect_pods() {
     gum style --bold --foreground 212 "Inspecting pods in the cluster"
-    watch -n 2 'kubectl get pods -A | grep "Pending\|CrashLoopBackOff\|Error\|ContainerCreating\|ImagePullBackOff\|ErrImagePull" || true'
+    watch -n 5 'kubectl get pods -A | grep "Pending\|CrashLoopBackOff\|Error\|ContainerCreating\|ImagePullBackOff\|ErrImagePull" || true'
 }
 
 show_production(){


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add pod inspection functionality to captain utils

- Integrate new inspect_pods option into production menu

- Filter non-running pod statuses for debugging


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["show_production menu"] --> B["inspect_pods option"]
  B --> C["handle_inspect_pods function"]
  C --> D["kubectl get pods with status filter"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>captain_utils.sh</strong><dd><code>Add pod inspection functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/tools/captain_utils.sh

<ul><li>Add <code>handle_inspect_pods</code> function to monitor pod statuses<br> <li> Include "inspect_pods" option in production menu choices<br> <li> Filter pods by non-running states (Pending, CrashLoopBackOff, etc.)<br> <li> Add conditional handler for inspect_pods component</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/codespaces/pull/354/files#diff-f913eaac92e95bb1e92070a682be303cda1e0b627c14a6d86c36779d5b4cfb1e">+10/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

