### PR TITLE
feat: update docker image references to use caching

### DIFF
--- a/developer-setup.sh
+++ b/developer-setup.sh
@@ -220,7 +220,7 @@ dev() {
 
             # --- Check Cached Images ---
             local cached_images
-            cached_images=$(sudo docker images --format "{{.Repository}}:{{.Tag}}" | grep "mirror.gpkg.io/glueops/mirror/glueops/codespaces")
+            cached_images=$(sudo docker images --format "{{.Repository}}:{{.Tag}}" | grep "replicas.mirror.gpkg.io/proxy-ghcr-io/glueops/codespaces")
 
             # --- Prepare Options for Gum (Using Simplified Markers) ---
             local options=()
@@ -292,7 +292,7 @@ dev() {
                 -v /var/run/docker.sock:/var/run/docker.sock \
                 -v /var/run/tailscale/tailscaled.sock:/var/run/tailscale/tailscaled.sock \
                 -w /workspaces/glueops \
-                "mirror.gpkg.io/glueops/mirror/glueops/codespaces:${CONTAINER_TAG_TO_USE}" bash; then
+                "replicas.mirror.gpkg.io/proxy-ghcr-io/glueops/codespaces:${CONTAINER_TAG_TO_USE}" bash; then
              gum style --padding "0 1" --foreground=196 --bold \
                 "❌ ERROR:" "Failed to create or start container '$CONTAINER_NAME' with tag '$CONTAINER_TAG_TO_USE'." >&2
              # Added suggestion from previous step, kept simple
@@ -365,9 +365,9 @@ if [ -z "$GLUEOPS_CODESPACES_CONTAINER_TAG" ]; then
 else
   # If the variable is set, pull the Docker image using the tag
   echo "Pulling down codespace version: $GLUEOPS_CODESPACES_CONTAINER_TAG"
-  sudo docker pull ghcr.io/glueops/codespaces:$GLUEOPS_CODESPACES_CONTAINER_TAG
+  until sudo docker pull replicas.mirror.gpkg.io/proxy-ghcr-io/glueops/codespaces:$GLUEOPS_CODESPACES_CONTAINER_TAG; do echo "Docker pull failed, retrying in 20 seconds..."; sleep 20; done
   # The glueops/mirror replication has a delay of 5-20minutes. This re-tagging is to leverage the mirror endpoint and still be able to use an existing cache.
-  sudo docker tag ghcr.io/glueops/codespaces:$GLUEOPS_CODESPACES_CONTAINER_TAG mirror.gpkg.io/glueops/mirror/glueops/codespaces:$GLUEOPS_CODESPACES_CONTAINER_TAG
+  sudo docker tag ghcr.io/glueops/codespaces:$GLUEOPS_CODESPACES_CONTAINER_TAG replicas.mirror.gpkg.io/proxy-ghcr-io/glueops/codespaces:$GLUEOPS_CODESPACES_CONTAINER_TAG
 fi
 
 echo -e "\n\n\n\n\nPlease reboot using: sudo reboot \n\n"

--- a/developer-setup.sh
+++ b/developer-setup.sh
@@ -362,12 +362,10 @@ curl -fsSL https://tailscale.com/install.sh | sh
 
 if [ -z "$GLUEOPS_CODESPACES_CONTAINER_TAG" ]; then
   echo "GLUEOPS_CODESPACES_CONTAINER_TAG is not set."
+  echo "Please manually run: docker pull replicas.mirror.gpkg.io/proxy-ghcr-io/glueops/codespaces:<TAG> before you run `dev`"
 else
-  # If the variable is set, pull the Docker image using the tag
   echo "Pulling down codespace version: $GLUEOPS_CODESPACES_CONTAINER_TAG"
   until sudo docker pull replicas.mirror.gpkg.io/proxy-ghcr-io/glueops/codespaces:$GLUEOPS_CODESPACES_CONTAINER_TAG; do echo "Docker pull failed, retrying in 20 seconds..."; sleep 20; done
-  # The glueops/mirror replication has a delay of 5-20minutes. This re-tagging is to leverage the mirror endpoint and still be able to use an existing cache.
-  sudo docker tag ghcr.io/glueops/codespaces:$GLUEOPS_CODESPACES_CONTAINER_TAG replicas.mirror.gpkg.io/proxy-ghcr-io/glueops/codespaces:$GLUEOPS_CODESPACES_CONTAINER_TAG
 fi
 
 echo -e "\n\n\n\n\nPlease reboot using: sudo reboot \n\n"

--- a/developer-setup.sh
+++ b/developer-setup.sh
@@ -362,7 +362,7 @@ curl -fsSL https://tailscale.com/install.sh | sh
 
 if [ -z "$GLUEOPS_CODESPACES_CONTAINER_TAG" ]; then
   echo "GLUEOPS_CODESPACES_CONTAINER_TAG is not set."
-  echo "Please manually run: docker pull replicas.mirror.gpkg.io/proxy-ghcr-io/glueops/codespaces:<TAG> before you run `dev`"
+  echo "Please manually run: docker pull replicas.mirror.gpkg.io/proxy-ghcr-io/glueops/codespaces:<TAG> before you run 'dev'"
 else
   echo "Pulling down codespace version: $GLUEOPS_CODESPACES_CONTAINER_TAG"
   until sudo docker pull replicas.mirror.gpkg.io/proxy-ghcr-io/glueops/codespaces:$GLUEOPS_CODESPACES_CONTAINER_TAG; do echo "Docker pull failed, retrying in 20 seconds..."; sleep 20; done


### PR DESCRIPTION
### **User description**
This adds about 60-90 seconds to the build. This change will help in situations where we bootstrap using `curl -sL setup.glueops.dev | bash`. The script is mostly used when running k3d deployments.


___

### **PR Type**
Enhancement


___

### **Description**
- Update Docker image references to use new mirror registry

- Add retry logic for Docker pull operations

- Improve container image caching strategy


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old Mirror Registry"] --> B["New Replicas Registry"]
  B --> C["Enhanced Pull Logic"]
  C --> D["Improved Caching"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>developer-setup.sh</strong><dd><code>Update registry URLs and add pull retry logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

developer-setup.sh

<ul><li>Replace <code>mirror.gpkg.io/glueops/mirror/</code> with <br><code>replicas.mirror.gpkg.io/proxy-ghcr-io/</code><br> <li> Add retry loop with 20-second intervals for Docker pull failures<br> <li> Update cached image filtering to use new registry path<br> <li> Maintain existing tagging strategy for cache leverage</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/codespaces/pull/357/files#diff-935e77d8a09f6b81dc8897c83ed83ce04e4a30f07e06587600390cfb7c538ac9">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

