### PR TITLE
feat: install krew + kubectl oidc-login plugin

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -36,6 +36,9 @@ ARG VERSION_K3D=5.8.3
 ARG VERSION_HASHICORP_PACKER=1.15.1
 # renovate: datasource=github-tags depName=kubernetes-sigs/krew
 ARG VERSION_KREW=0.4.5
+# Pinned to plugins/oidc-login.yaml at the krew-index commit below (currently oidc-login v1.36.2).
+# To bump: gh api "repos/kubernetes-sigs/krew-index/commits?path=plugins/oidc-login.yaml&per_page=1" --jq '.[0].sha'
+ARG KREW_INDEX_OIDC_LOGIN_SHA=0bae2a56ef8093f1e499b01010e072808049b44d
 
 # https://developer.hashicorp.com/vault/docs/commands#vault_skip_verify
 # https://github.com/GlueOps/terraform-module-kubernetes-hashicorp-vault-configuration/wiki
@@ -152,7 +155,7 @@ RUN cd /tmp \
     && ./krew-linux_amd64 install krew \
     && rm -f krew-linux_amd64 krew-linux_amd64.tar.gz LICENSE \
     && export PATH="$HOME/.krew/bin:$PATH" \
-    && kubectl krew install oidc-login \
+    && kubectl krew install --manifest-url=https://raw.githubusercontent.com/kubernetes-sigs/krew-index/${KREW_INDEX_OIDC_LOGIN_SHA}/plugins/oidc-login.yaml \
     && kubectl krew version \
     && kubectl oidc-login --help > /dev/null
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -34,6 +34,8 @@ ARG VERSION_ARGO_CD_CLI=3.2.11
 ARG VERSION_K3D=5.8.3
 # renovate: datasource=github-tags depName=hashicorp/packer
 ARG VERSION_HASHICORP_PACKER=1.15.1
+# renovate: datasource=github-tags depName=kubernetes-sigs/krew
+ARG VERSION_KREW=0.4.5
 
 # https://developer.hashicorp.com/vault/docs/commands#vault_skip_verify
 # https://github.com/GlueOps/terraform-module-kubernetes-hashicorp-vault-configuration/wiki
@@ -104,7 +106,7 @@ RUN wget "https://releases.hashicorp.com/packer/${VERSION_HASHICORP_PACKER}/pack
     && rm packer_${VERSION_HASHICORP_PACKER}_linux_amd64.zip \
     && rm LICENSE.txt
 
-RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq &&\ 
+RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq &&\
     sudo chmod +x /usr/local/bin/yq
 
 # Install code tunnel so we can run outside of github codespaces easily
@@ -143,6 +145,17 @@ USER vscode
 RUN code --install-extension MS-vsliveshare.vsliveshare --extensions-dir /home/vscode/.vscode-remote/extensions
 RUN code --install-extension GitHub.codespaces --extensions-dir /home/vscode/.vscode-remote/extensions
 
+# Install krew (kubectl plugin manager) into $HOME/.krew, then install the oidc-login plugin
+RUN cd /tmp \
+    && curl -fsSLO https://github.com/kubernetes-sigs/krew/releases/download/v${VERSION_KREW}/krew-linux_amd64.tar.gz \
+    && tar zxf krew-linux_amd64.tar.gz \
+    && ./krew-linux_amd64 install krew \
+    && rm -f krew-linux_amd64 krew-linux_amd64.tar.gz LICENSE \
+    && export PATH="$HOME/.krew/bin:$PATH" \
+    && kubectl krew install oidc-login \
+    && kubectl krew version \
+    && kubectl oidc-login --help > /dev/null
+
 RUN curl -L https://nixos.org/nix/install | bash -s -- --no-daemon
 # 0.14.0 came out a couple weeks ago and it appears to be problematic. So pinning and manually upgrading seems like a good option
 ENV DEVBOX_USE_VERSION=0.13.0
@@ -176,7 +189,7 @@ RUN echo '\n# === Backup & Git Reminder ===' | tee -a /home/vscode/.zshrc && \
     echo 'echo -e "\e[1;31m⚠️  WARNING: No backups are configured. You are responsible for any data loss.\e[0m"' | tee -a /home/vscode/.zshrc && \
     echo 'echo -e "\e[1;33m💡 Tip: Use '\''git commit'\'' and '\''git push'\'' regularly to avoid losing your work.\e[0m"' | tee -a /home/vscode/.zshrc && \
     echo '# =============================' | tee -a /home/vscode/.zshrc && \
-    echo 'export PATH="$HOME/.local/bin:$PATH"' | tee -a /home/vscode/.zshrc && \
+    echo 'export PATH="$HOME/.local/bin:$HOME/.krew/bin:$PATH"' | tee -a /home/vscode/.zshrc && \
     chown vscode:vscode /home/vscode/.zshrc
 
 USER root

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -156,6 +156,9 @@ RUN cd /tmp \
     && kubectl krew version \
     && kubectl oidc-login --help > /dev/null
 
+# Make $HOME/.krew/bin available to every process (including non-interactive shells and kubeconfig exec: plugins)
+ENV PATH=/home/vscode/.krew/bin:$PATH
+
 RUN curl -L https://nixos.org/nix/install | bash -s -- --no-daemon
 # 0.14.0 came out a couple weeks ago and it appears to be problematic. So pinning and manually upgrading seems like a good option
 ENV DEVBOX_USE_VERSION=0.13.0
@@ -189,11 +192,11 @@ RUN echo '\n# === Backup & Git Reminder ===' | tee -a /home/vscode/.zshrc && \
     echo 'echo -e "\e[1;31m⚠️  WARNING: No backups are configured. You are responsible for any data loss.\e[0m"' | tee -a /home/vscode/.zshrc && \
     echo 'echo -e "\e[1;33m💡 Tip: Use '\''git commit'\'' and '\''git push'\'' regularly to avoid losing your work.\e[0m"' | tee -a /home/vscode/.zshrc && \
     echo '# =============================' | tee -a /home/vscode/.zshrc && \
-    echo 'export PATH="$HOME/.local/bin:$HOME/.krew/bin:$PATH"' | tee -a /home/vscode/.zshrc && \
-    chown vscode:vscode /home/vscode/.zshrc
+    echo 'export PATH="$HOME/.local/bin:$HOME/.krew/bin:$PATH"' | tee -a /home/vscode/.zshrc /home/vscode/.bashrc && \
+    chown vscode:vscode /home/vscode/.zshrc /home/vscode/.bashrc
 
 USER root
-RUN mkdir -p /home/vscode/.kube
+RUN mkdir -p /home/vscode/.kube && chmod 0700 /home/vscode/.kube
 RUN chown -R vscode:vscode /home/vscode
 ENTRYPOINT [ "/usr/local/share/docker-init.sh" ]
 CMD [ "sleep", "infinity" ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -36,9 +36,6 @@ ARG VERSION_K3D=5.8.3
 ARG VERSION_HASHICORP_PACKER=1.15.1
 # renovate: datasource=github-tags depName=kubernetes-sigs/krew
 ARG VERSION_KREW=0.4.5
-# Pinned to plugins/oidc-login.yaml at the krew-index commit below (currently oidc-login v1.36.2).
-# To bump: gh api "repos/kubernetes-sigs/krew-index/commits?path=plugins/oidc-login.yaml&per_page=1" --jq '.[0].sha'
-ARG KREW_INDEX_OIDC_LOGIN_SHA=0bae2a56ef8093f1e499b01010e072808049b44d
 
 # https://developer.hashicorp.com/vault/docs/commands#vault_skip_verify
 # https://github.com/GlueOps/terraform-module-kubernetes-hashicorp-vault-configuration/wiki
@@ -155,7 +152,7 @@ RUN cd /tmp \
     && ./krew-linux_amd64 install krew \
     && rm -f krew-linux_amd64 krew-linux_amd64.tar.gz LICENSE \
     && export PATH="$HOME/.krew/bin:$PATH" \
-    && kubectl krew install --manifest-url=https://raw.githubusercontent.com/kubernetes-sigs/krew-index/${KREW_INDEX_OIDC_LOGIN_SHA}/plugins/oidc-login.yaml \
+    && kubectl krew install oidc-login \
     && kubectl krew version \
     && kubectl oidc-login --help > /dev/null
 


### PR DESCRIPTION
## Summary

- Installs [krew](https://krew.sigs.k8s.io/) (the kubectl plugin manager) and pre-installs the `oidc-login` plugin so users can authenticate to GlueOps clusters via OIDC without any manual setup.
- Matches the steps in our developer docs (`kubectl krew install oidc-login`, `$HOME/.krew/bin` on PATH) — but now those steps are baked into the image.

## Changes

- New `VERSION_KREW` ARG, renovate-tracked from `kubernetes-sigs/krew`.
- krew installs into `$HOME/.krew` as the `vscode` user, then `kubectl krew install oidc-login` runs.
- Build fails fast if either `kubectl krew version` or `kubectl oidc-login --help` does not succeed.
- `$HOME/.krew/bin` appended to PATH in `/home/vscode/.zshrc`.

## Test plan

- [ ] Build the image (`docker build -t test .devcontainer/`) and confirm both `kubectl krew version` and `kubectl oidc-login --help` succeed during build.
- [ ] Launch a codespace from a pre-release tag (`!vm` in `#testing-developer-workspaces`) and verify `kubectl krew list` shows `oidc-login` without any user action.
- [ ] In the same codespace, run `kubectl oidc-login --help` to confirm the plugin resolves through `$HOME/.krew/bin` on PATH.
- [ ] Walk through the GlueOps docs flow (Access Your Cluster with kubectl) end to end and confirm the sign-in works.

Companion docs: GlueOps/glueops-dev#482 — Reader Plus tier, also referencing this same krew/oidc-login flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)