### PR TITLE
feat: install cloudflared in devcontainer image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -36,6 +36,8 @@ ARG VERSION_K3D=5.8.3
 ARG VERSION_HASHICORP_PACKER=1.15.1
 # renovate: datasource=github-tags depName=kubernetes-sigs/krew
 ARG VERSION_KREW=0.5.0
+# renovate: datasource=github-tags depName=cloudflare/cloudflared
+ARG VERSION_CLOUDFLARED=2026.6.1
 
 # https://developer.hashicorp.com/vault/docs/commands#vault_skip_verify
 # https://github.com/GlueOps/terraform-module-kubernetes-hashicorp-vault-configuration/wiki
@@ -108,6 +110,10 @@ RUN wget "https://releases.hashicorp.com/packer/${VERSION_HASHICORP_PACKER}/pack
 
 RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq &&\
     sudo chmod +x /usr/local/bin/yq
+
+# dpkg --print-architecture (amd64/arm64) matches cloudflared's asset naming, so this works for a future multi-arch build
+RUN curl -Lo /usr/local/bin/cloudflared https://github.com/cloudflare/cloudflared/releases/download/${VERSION_CLOUDFLARED}/cloudflared-linux-$(dpkg --print-architecture) \
+    && chmod +x /usr/local/bin/cloudflared
 
 # Install code tunnel so we can run outside of github codespaces easily
 RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > packages.microsoft.gpg \


### PR DESCRIPTION
Adds the [`cloudflared`](https://github.com/cloudflare/cloudflared) binary to the devcontainer image.

## What changed
`.devcontainer/Dockerfile`:
- New pinned version arg with a Renovate annotation (matches every other tool in this file):
  ```dockerfile
  # renovate: datasource=github-tags depName=cloudflare/cloudflared
  ARG VERSION_CLOUDFLARED=2026.6.1
  ```
- Install step to `/usr/local/bin/cloudflared`:
  ```dockerfile
  RUN curl -Lo /usr/local/bin/cloudflared https://github.com/cloudflare/cloudflared/releases/download/${VERSION_CLOUDFLARED}/cloudflared-linux-$(dpkg --print-architecture) \
      && chmod +x /usr/local/bin/cloudflared
  ```

## Arch auto-detection (multi-arch ready)
The URL uses `$(dpkg --print-architecture)` instead of a hardcoded `amd64`. `dpkg --print-architecture` returns `amd64` / `arm64`, which matches cloudflared's release asset names (`cloudflared-linux-amd64`, `cloudflared-linux-arm64`) exactly — so this keeps working unchanged if the image becomes a multi-arch build. This mirrors the existing `dpkg --print-architecture` usage already in this Dockerfile (the 1Password install). Both the amd64 and arm64 asset URLs were verified to resolve (HTTP 200).

## Note on pinning vs `latest`
The original request used the `releases/latest/download/...` URL. I pinned to the current release (`2026.6.1`) instead so builds are reproducible and Renovate keeps it current — consistent with how every other binary in this Dockerfile is managed. Happy to switch to `latest` if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)