### PR TITLE
feat: install claude code cli in devcontainer image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -36,6 +36,8 @@ ARG VERSION_K3D=5.8.3
 ARG VERSION_HASHICORP_PACKER=1.15.1
 # renovate: datasource=github-tags depName=kubernetes-sigs/krew
 ARG VERSION_KREW=0.5.0
+# renovate: datasource=npm depName=@anthropic-ai/claude-code
+ARG VERSION_CLAUDE_CODE=2.1.197
 # renovate: datasource=github-tags depName=cloudflare/cloudflared
 ARG VERSION_CLOUDFLARED=2026.6.1
 
@@ -169,6 +171,10 @@ RUN curl -L https://nixos.org/nix/install | bash -s -- --no-daemon
 # 0.14.0 came out a couple weeks ago and it appears to be problematic. So pinning and manually upgrading seems like a good option
 ENV DEVBOX_USE_VERSION=0.13.0
 RUN curl -fsSL https://get.jetify.com/devbox | bash -s -- -f
+
+# Install Claude Code via the native (nodeless) installer into ~/.local/bin, which is already on PATH.
+# npm isn't available at image-build time (node comes from a devcontainer feature applied afterwards).
+RUN curl -fsSL https://claude.ai/install.sh | bash -s ${VERSION_CLAUDE_CODE}
 
 
 RUN mkdir -p /home/vscode/.vscode-server


### PR DESCRIPTION
Installs the [Claude Code](https://code.claude.com/docs) CLI into the devcontainer image. The image already sets `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` but never actually installed the CLI — this adds it.

## What changed
`.devcontainer/Dockerfile`:
- Pinned version arg with a Renovate annotation (matches every other tool in this file):
  ```dockerfile
  # renovate: datasource=npm depName=@anthropic-ai/claude-code
  ARG VERSION_CLAUDE_CODE=2.1.197
  ```
- Install step in the `USER vscode` section (so it lands in the vscode user's `~/.local/bin`, already on PATH):
  ```dockerfile
  RUN curl -fsSL https://claude.ai/install.sh | bash -s ${VERSION_CLAUDE_CODE}
  ```

## Why the native installer (not `npm install -g`)
`node`/`npm` are provided by a **devcontainer feature**, which is applied *after* the Dockerfile builds — so `npm` isn't available at image-build time and `npm install -g @anthropic-ai/claude-code` would fail. The native (nodeless) installer downloads a standalone binary and needs no runtime. Its version arg tracks the same releases as the npm package, so Renovate's `datasource=npm depName=@anthropic-ai/claude-code` keeps it current.

## Arch-aware (multi-arch ready)
The installer auto-detects platform (`x64`/`arm64`, and musl vs glibc), so like the cloudflared change it keeps working if this image becomes a multi-arch build. Verified the pinned version's manifest and `linux-x64` binary both resolve (HTTP 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)