### PR TITLE
feat: install kube-prometheus-stack CRDs during argocd install

### DIFF
--- a/.devcontainer/tools/captain_utils.sh
+++ b/.devcontainer/tools/captain_utils.sh
@@ -106,14 +106,18 @@ install_kube_prometheus_stack_crds() {
         return 1
     fi
     crds_ref="kube-prometheus-stack-${kps_version}"
-    gum style --bold --foreground 212 "Installing kube-prometheus-stack CRDs (${crds_ref}):"
-    local crds_dir
-    crds_dir=$(mktemp -d)
-    git -c advice.detachedHead=false clone --quiet --depth 1 --branch "$crds_ref" --filter=blob:none --sparse \
-        https://github.com/prometheus-community/helm-charts.git "$crds_dir"
-    git -C "$crds_dir" sparse-checkout set --no-cone charts/kube-prometheus-stack/charts/crds/crds
-    kubectl apply --server-side --force-conflicts -R -f "$crds_dir/charts/kube-prometheus-stack/charts/crds/crds"
-    rm -rf "$crds_dir"
+    local install_cmds
+    install_cmds=$(cat <<EOF
+crds_dir=\$(mktemp -d)
+git -c advice.detachedHead=false clone --quiet --depth 1 --branch "$crds_ref" --filter=blob:none --sparse https://github.com/prometheus-community/helm-charts.git "\$crds_dir"
+git -C "\$crds_dir" sparse-checkout set --no-cone charts/kube-prometheus-stack/charts/crds/crds
+kubectl apply --server-side --force-conflicts -R -f "\$crds_dir/charts/kube-prometheus-stack/charts/crds/crds"
+rm -rf "\$crds_dir"
+EOF
+)
+    gum style --bold --foreground 212 "Installing kube-prometheus-stack CRDs (${crds_ref}) using the following commands (copy to re-run or debug):"
+    echo "$install_cmds"
+    eval "$install_cmds"
 }
 
 handle_argocd() {

--- a/.devcontainer/tools/captain_utils.sh
+++ b/.devcontainer/tools/captain_utils.sh
@@ -70,7 +70,7 @@ handle_platform_upgrades() {
 
         helm_diff_cmd="helm diff --color upgrade \"$component\" \"$chart_name\" --version \"$version\" -f \"$target_file\" -f \"$overrides_file\" -n \"$namespace\" --allow-unreleased"
 
-        gum style --bold --foreground 212 "Running diff with the following command (copy to re-run or debug, e.g. swap 'diff --color upgrade' for 'template'):"
+        gum style --bold --foreground 212 "Running diff with the following command (copy to re-run or debug, e.g. swap 'diff --color upgrade' for 'template' and drop '--allow-unreleased'):"
         echo "$helm_diff_cmd"
         eval "$helm_diff_cmd | gum pager" # Execute the main helm diff command
         gum style --bold --foreground 212 "✅ Diff complete."
@@ -93,7 +93,7 @@ handle_platform_upgrades() {
 # Server-side apply is used because the prometheus CRDs are too large for client-side
 # apply (mirrors the app's Replace=true).
 install_kube_prometheus_stack_crds() {
-    local kps_version crds_ref crd
+    local kps_version crds_ref crds_dir=""
     if [ "$environment" = "production" ]; then
         kps_version=$(yq '.versions[] | select(.name == "kube_prometheus_stack_version") | .version' VERSIONS/glueops.yaml)
     else
@@ -106,16 +106,20 @@ install_kube_prometheus_stack_crds() {
     crds_ref="kube-prometheus-stack-${kps_version}"
     local install_cmds
     install_cmds=$(cat <<EOF
-crds_dir=\$(mktemp -d)
-git -c advice.detachedHead=false clone --quiet --depth 1 --branch "$crds_ref" --filter=blob:none --sparse https://github.com/prometheus-community/helm-charts.git "\$crds_dir"
-git -C "\$crds_dir" sparse-checkout set --no-cone charts/kube-prometheus-stack/charts/crds/crds
-kubectl apply --server-side --force-conflicts -R -f "\$crds_dir/charts/kube-prometheus-stack/charts/crds/crds"
+crds_dir=\$(mktemp -d) &&
+GIT_TERMINAL_PROMPT=0 git -c advice.detachedHead=false clone --quiet --depth 1 --branch "$crds_ref" --filter=blob:none --sparse https://github.com/prometheus-community/helm-charts.git "\$crds_dir" &&
+git -C "\$crds_dir" sparse-checkout set --no-cone charts/kube-prometheus-stack/charts/crds/crds &&
+kubectl apply --server-side --force-conflicts -R -f "\$crds_dir/charts/kube-prometheus-stack/charts/crds/crds" &&
 rm -rf "\$crds_dir"
 EOF
 )
     gum style --bold --foreground 212 "Installing kube-prometheus-stack CRDs (${crds_ref}) using the following commands (copy to re-run or debug):"
     echo "$install_cmds"
-    eval "$install_cmds"
+    if ! eval "$install_cmds"; then
+        if [ -d "$crds_dir" ]; then rm -rf "$crds_dir"; fi
+        gum style --bold --foreground 196 "❌ kube-prometheus-stack CRD install failed."
+        return 1
+    fi
 }
 
 handle_argocd() {
@@ -152,13 +156,13 @@ handle_argocd() {
             local argocd_crd_versions=`v($(helm search repo argo/argo-cd --versions -o json | jq --arg chart_helm_version "$version" -r '.[] | select(.version == $chart_helm_version).app_version' | sed 's/^v//'))`
         fi
         chosen_crd_version=$(gum choose "${argocd_crd_versions[@]}" "Back")
-        pre_commands="kubectl apply -k \"https://github.com/argoproj/argo-cd/manifests/crds?ref=$chosen_crd_version\" && helm repo update && install_kube_prometheus_stack_crds"
+        pre_commands="kubectl apply -k \"https://github.com/argoproj/argo-cd/manifests/crds?ref=$chosen_crd_version\" && helm repo update"
         # Check if user wants to go back
         if [ "$chosen_crd_version" = "Back" ]; then
             return
         fi
         
-        gum style --bold --foreground 212 "Running diff with the following command (copy to re-run or debug, e.g. swap 'diff --color upgrade' for 'template'):"
+        gum style --bold --foreground 212 "Running diff with the following command (copy to re-run or debug, e.g. swap 'diff --color upgrade' for 'template' and drop '--allow-unreleased'):"
         echo "$helm_diff_cmd"
         eval "$helm_diff_cmd | gum pager" # Execute the main helm diff command
         gum style --bold --foreground 212 "✅ Diff complete."
@@ -171,9 +175,9 @@ handle_argocd() {
         if [ -n "$pre_commands" ] && [ -n "$chosen_crd_version" ]; then
             gum style --bold --foreground 212 "Executing pre-commands for $component (copy to re-run or debug):"
             echo "$pre_commands"
-            eval "$pre_commands"
-            if [ $? -ne 0 ]; then
-                gum style --bold --foreground 196 "❌ Pre-commands failed. Aborting diff."
+            # The tested condition suspends set -e so failures land in the retry path below
+            if ! eval "$pre_commands" || ! install_kube_prometheus_stack_crds; then
+                gum style --bold --foreground 196 "❌ Pre-commands failed. Aborting upgrade."
                 continue # Allow user to retry or go back
             fi
             gum style --bold --foreground 212 "✅ Pre-commands complete."

--- a/.devcontainer/tools/captain_utils.sh
+++ b/.devcontainer/tools/captain_utils.sh
@@ -69,23 +69,21 @@ handle_platform_upgrades() {
         echo "chosen version: $version for $chart_name"
 
         helm_diff_cmd="helm diff --color upgrade \"$component\" \"$chart_name\" --version \"$version\" -f \"$target_file\" -f \"$overrides_file\" -n \"$namespace\" --allow-unreleased"
-        
-        set -x
+
+        gum style --bold --foreground 212 "Running diff with the following command (copy to re-run or debug, e.g. swap 'diff --color upgrade' for 'template'):"
+        echo "$helm_diff_cmd"
         eval "$helm_diff_cmd | gum pager" # Execute the main helm diff command
         gum style --bold --foreground 212 "✅ Diff complete."
-        set +x
-        
+
         if ! gum confirm "Apply upgrade"; then
             return
         fi
-        
-        # Running helm diff command
-        gum style --bold --foreground 212 "The following commands will be executed:"
-        
-        set -x
-        helm upgrade --install "$component" "$chart_name" --version "$version" -f "$target_file" -f "$overrides_file" -n "$namespace" --create-namespace 
-        set +x
-        return 
+
+        helm_upgrade_cmd="helm upgrade --install \"$component\" \"$chart_name\" --version \"$version\" -f \"$target_file\" -f \"$overrides_file\" -n \"$namespace\" --create-namespace"
+        gum style --bold --foreground 212 "The following commands will be executed (copy to re-run or debug):"
+        echo "$helm_upgrade_cmd"
+        eval "$helm_upgrade_cmd"
+        return
     done
 }
 
@@ -160,35 +158,31 @@ handle_argocd() {
             return
         fi
         
-        set -x
+        gum style --bold --foreground 212 "Running diff with the following command (copy to re-run or debug, e.g. swap 'diff --color upgrade' for 'template'):"
+        echo "$helm_diff_cmd"
         eval "$helm_diff_cmd | gum pager" # Execute the main helm diff command
         gum style --bold --foreground 212 "✅ Diff complete."
-        set +x
-        
+
         if ! gum confirm "Apply upgrade"; then
             return
         fi
-        
-        # Running helm diff command
-        gum style --bold --foreground 212 "The following commands will be executed:"
-        
+
         # New: Execute pre_commands if defined
         if [ -n "$pre_commands" ] && [ -n "$chosen_crd_version" ]; then
-            gum style --bold --foreground 212 "Executing pre-commands for $component:"
-            set -x
+            gum style --bold --foreground 212 "Executing pre-commands for $component (copy to re-run or debug):"
+            echo "$pre_commands"
             eval "$pre_commands"
             if [ $? -ne 0 ]; then
                 gum style --bold --foreground 196 "❌ Pre-commands failed. Aborting diff."
-                set +x
                 continue # Allow user to retry or go back
             fi
-            set +x
             gum style --bold --foreground 212 "✅ Pre-commands complete."
         fi
-        set -x
-        helm upgrade --install "$component" "$chart_name" --version "$version" -f "$target_file"  -n "$namespace" --create-namespace --skip-crds
-        set +x
-        return 
+        helm_upgrade_cmd="helm upgrade --install \"$component\" \"$chart_name\" --version \"$version\" -f \"$target_file\" -n \"$namespace\" --create-namespace --skip-crds"
+        gum style --bold --foreground 212 "The following commands will be executed (copy to re-run or debug):"
+        echo "$helm_upgrade_cmd"
+        eval "$helm_upgrade_cmd"
+        return
     done
 
 }

--- a/.devcontainer/tools/captain_utils.sh
+++ b/.devcontainer/tools/captain_utils.sh
@@ -89,6 +89,33 @@ handle_platform_upgrades() {
     done
 }
 
+# Installs the kube-prometheus-stack CRDs, replicating the kube-prometheus-stack-crds
+# ArgoCD app from platform-helm-chart-platform. The chart version comes from
+# VERSIONS/glueops.yaml (kube_prometheus_stack_version) like the other components.
+# Server-side apply is used because the prometheus CRDs are too large for client-side
+# apply (mirrors the app's Replace=true).
+install_kube_prometheus_stack_crds() {
+    local kps_version crds_ref crd
+    if [ "$environment" = "production" ]; then
+        kps_version=$(yq '.versions[] | select(.name == "kube_prometheus_stack_version") | .version' VERSIONS/glueops.yaml)
+    else
+        kps_version=$(curl -sf "https://raw.githubusercontent.com/GlueOps/platform-helm-chart-platform/main/templates/application-kube-prometheus-stack-crds.yaml" | yq '.spec.source.targetRevision' | sed 's/^kube-prometheus-stack-//')
+    fi
+    if [ -z "$kps_version" ]; then
+        gum style --bold --foreground 196 "❌ kube_prometheus_stack_version not found in VERSIONS/glueops.yaml. Re-run terraform with an updated terraform-module-cloud-multy-prerequisites to regenerate it."
+        return 1
+    fi
+    crds_ref="kube-prometheus-stack-${kps_version}"
+    gum style --bold --foreground 212 "Installing kube-prometheus-stack CRDs (${crds_ref}):"
+    local crds_dir
+    crds_dir=$(mktemp -d)
+    git -c advice.detachedHead=false clone --quiet --depth 1 --branch "$crds_ref" --filter=blob:none --sparse \
+        https://github.com/prometheus-community/helm-charts.git "$crds_dir"
+    git -C "$crds_dir" sparse-checkout set --no-cone charts/kube-prometheus-stack/charts/crds/crds
+    kubectl apply --server-side --force-conflicts -R -f "$crds_dir/charts/kube-prometheus-stack/charts/crds/crds"
+    rm -rf "$crds_dir"
+}
+
 handle_argocd() {
     if [ "$environment" = "production" ]; then
         argocd_version=`yq '.versions[] | select(.name == "argocd_helm_chart_version") | .version' VERSIONS/glueops.yaml`
@@ -123,7 +150,7 @@ handle_argocd() {
             local argocd_crd_versions=`v($(helm search repo argo/argo-cd --versions -o json | jq --arg chart_helm_version "$version" -r '.[] | select(.version == $chart_helm_version).app_version' | sed 's/^v//'))`
         fi
         chosen_crd_version=$(gum choose "${argocd_crd_versions[@]}" "Back")
-        pre_commands="kubectl apply -k \"https://github.com/argoproj/argo-cd/manifests/crds?ref=$chosen_crd_version\" && helm repo update"
+        pre_commands="kubectl apply -k \"https://github.com/argoproj/argo-cd/manifests/crds?ref=$chosen_crd_version\" && helm repo update && install_kube_prometheus_stack_crds"
         # Check if user wants to go back
         if [ "$chosen_crd_version" = "Back" ]; then
             return


### PR DESCRIPTION
## Summary
- `handle_argocd` now installs the kube-prometheus-stack CRDs as part of its pre-commands (right after the ArgoCD CRDs), replicating the `kube-prometheus-stack-crds` ArgoCD Application from [platform-helm-chart-platform](https://github.com/GlueOps/platform-helm-chart-platform/blob/main/templates/application-kube-prometheus-stack-crds.yaml) with plain kubectl.

## How it works
- The chart version is read from `VERSIONS/glueops.yaml` (`kube_prometheus_stack_version`) in production, like the other components — added by GlueOps/terraform-module-cloud-multy-prerequisites#648. Dev mode falls back to the `targetRevision` pinned on `main` of platform-helm-chart-platform. A clear error is shown if the key is missing (older `VERSIONS/glueops.yaml` — re-run terraform to regenerate).
- The whole CRD folder (`charts/kube-prometheus-stack/charts/crds/crds`) is sparse-cloned from `prometheus-community/helm-charts` at tag `kube-prometheus-stack-<version>` and applied in one `kubectl apply --server-side --force-conflicts -R -f` — no hardcoded file list, matching the app's `directory.recurse: true`.
- Server-side apply is the kubectl equivalent of the app's `Replace=true`: the prometheus/alertmanager CRDs blow past the 256KB last-applied-configuration annotation limit of client-side apply.

## Testing
- `bash -n` syntax check passes.
- Verified the sparse clone at tag `kube-prometheus-stack-59.1.0` materializes exactly the 10 CRD yamls; full apply needs a live cluster (`--server-side` can't pair with `--dry-run=client`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)