### PR TITLE
fix: make `code <file>` work in serve-web terminals

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -77,7 +77,7 @@ RUN curl -Lo /usr/local/bin/kubectl https://dl.k8s.io/release/v${VERSION_KUBECTL
 
 
 RUN apt update \
-    && apt install tmux dnsutils telnet iputils-ping jq certbot nethogs nload vim -y \
+    && apt install tmux dnsutils telnet iputils-ping jq certbot nethogs nload vim socat -y \
     && apt clean -y
 RUN curl -Lo /usr/local/bin/kind https://kind.sigs.k8s.io/dl/v${VERSION_KIND}/kind-linux-amd64 \
     && chmod +x /usr/local/bin/kind
@@ -205,18 +205,19 @@ RUN mkdir -p /home/vscode/.vscode-server/data/Machine/ && echo '{"workbench.colo
 # In these headless serve-web/tunnel sessions there is no X display, so running
 # `code <file>` in the terminal crashes ("Missing X server or $DISPLAY").
 # Drop a wrapper on $HOME/.local/bin (first on the interactive PATH, see .zshrc/.bashrc
-# below) that forwards to the serve-web/remote-cli shim, which opens files in the
-# already-running VS Code window via the $VSCODE_IPC_HOOK_CLI socket. The wrapper picks
-# the newest shim so it survives VS Code updates, and recovers from a stale socket after
-# a reconnect (see the inline comments). Only affects interactive shells; build-time
-# `code --install-extension` above still resolves to /usr/bin/code.
+# below) that forwards to the serve-web/remote-cli shim, which opens files in a running
+# VS Code window over its $VSCODE_IPC_HOOK_CLI socket. The wrapper picks the newest shim
+# so it survives VS Code updates, and routes to the newest live window socket so it keeps
+# working in long-lived shells (e.g. tmux) whose captured socket has gone stale (see the
+# inline comments). Only affects interactive shells; build-time `code --install-extension`
+# above still resolves to /usr/bin/code.
 RUN mkdir -p /home/vscode/.local/bin \
     && printf '%s\n' \
         '#!/usr/bin/env sh' \
         '# Route `code` to the VS Code serve-web/remote CLI shim instead of the GUI desktop' \
         '# binary (/usr/bin/code), which has no display in this container and crashes.' \
         '' \
-        '# 1. Locate the remote CLI shim. There is one per installed VS Code build, and the' \
+        '# 1. Locate the remote CLI shim. There is one per installed VS Code build and the' \
         '#    path embeds a build hash, so pick the newest to survive VS Code updates. The' \
         '#    -x check turns a found-but-not-executable match into the friendly error below' \
         '#    instead of an opaque `exec: Permission denied`.' \
@@ -229,20 +230,28 @@ RUN mkdir -p /home/vscode/.local/bin \
         '  exit 1' \
         'fi' \
         '' \
-        '# 2. The shim talks to the running window over the IPC socket named in' \
-        '#    $VSCODE_IPC_HOOK_CLI. That value is captured when the shell starts, so after a' \
-        '#    VS Code reconnect (container or server restart) it can name a socket that no' \
-        '#    longer exists. Only when the referenced socket is gone, fall back to the most' \
-        '#    recently created /tmp/vscode-ipc-*.sock so `code` keeps working without opening' \
-        '#    a fresh terminal. A still-present socket is left untouched, so routing stays' \
-        '#    correct when multiple windows (each with its own socket) are connected.' \
-        'if [ -z "$VSCODE_IPC_HOOK_CLI" ] || [ ! -S "$VSCODE_IPC_HOOK_CLI" ]; then' \
-        '  newest_sock=$(ls -t /tmp/vscode-ipc-*.sock 2>/dev/null | head -n1)' \
-        '  if [ -n "$newest_sock" ]; then' \
-        '    VSCODE_IPC_HOOK_CLI="$newest_sock"' \
+        '# 2. Choose the IPC socket of the window to open files in. $VSCODE_IPC_HOOK_CLI is' \
+        '#    captured when the shell starts, so a long-lived shell (e.g. a tmux server that' \
+        '#    outlives a VS Code reconnect) keeps pointing at an OLD window. That old socket' \
+        '#    often still accepts connections, so files silently open in a window you can no' \
+        '#    longer see. VS Code creates one socket per window/connection under /tmp, so the' \
+        '#    newest is your current window: prefer the newest socket that still accepts a' \
+        '#    connection, falling back to older ones. If none is reachable, keep whatever the' \
+        '#    environment provided so socket-less subcommands (code --version, etc.) still work.' \
+        'ipc_live() {' \
+        '  [ -S "$1" ] || return 1' \
+        '  # Best-effort connect probe to skip sockets whose window has gone away. socat is' \
+        '  # optional here: if it is not installed, treat an existing socket as usable.' \
+        '  command -v socat >/dev/null 2>&1 || return 0' \
+        '  socat -u OPEN:/dev/null UNIX-CONNECT:"$1" >/dev/null 2>&1' \
+        '}' \
+        'for sock in $(ls -t /tmp/vscode-ipc-*.sock 2>/dev/null); do' \
+        '  if ipc_live "$sock"; then' \
+        '    VSCODE_IPC_HOOK_CLI="$sock"' \
         '    export VSCODE_IPC_HOOK_CLI' \
+        '    break' \
         '  fi' \
-        'fi' \
+        'done' \
         '' \
         '# 3. Hand off to the shim, preserving every argument and its exit status.' \
         'exec "$shim" "$@"' \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -217,6 +217,15 @@ RUN mkdir -p /home/vscode/.local/bin \
         '# Route `code` to the VS Code serve-web/remote CLI shim instead of the GUI desktop' \
         '# binary (/usr/bin/code), which has no display in this container and crashes.' \
         '' \
+        '# 0. tunnel/serve-web are full-CLI subcommands the remote-cli shim does not implement' \
+        '#    (it would treat "tunnel" as a filename to open) and they need no window socket.' \
+        '#    Hand them to the real /usr/bin/code, which dispatches them to its bundled CLI and' \
+        '#    runs fine headless. Use the absolute path -- calling `code` here would recurse' \
+        '#    into this wrapper.' \
+        'case "$1" in' \
+        '  tunnel|serve-web) exec /usr/bin/code "$@" ;;' \
+        'esac' \
+        '' \
         '# 1. Locate the remote CLI shim. There is one per installed VS Code build and the' \
         '#    path embeds a build hash, so pick the newest to survive VS Code updates. The' \
         '#    -x check turns a found-but-not-executable match into the friendly error below' \
@@ -238,12 +247,17 @@ RUN mkdir -p /home/vscode/.local/bin \
         '#    newest is your current window: prefer the newest socket that still accepts a' \
         '#    connection, falling back to older ones. If none is reachable, keep whatever the' \
         '#    environment provided so socket-less subcommands (code --version, etc.) still work.' \
+        '#    LIMITATION: "newest socket" is the current window only with a single window/tab' \
+        '#    open. With multiple windows, or after an extension-host reload, files may open in' \
+        '#    another window -- serve-web exposes no API to target a specific window, so this is' \
+        '#    the best heuristic available.' \
         'ipc_live() {' \
         '  [ -S "$1" ] || return 1' \
         '  # Best-effort connect probe to skip sockets whose window has gone away. socat is' \
-        '  # optional here: if it is not installed, treat an existing socket as usable.' \
+        '  # optional here: if it is not installed, treat an existing socket as usable. The' \
+        '  # timeout bounds the connect so a pathological socket can never wedge `code`.' \
         '  command -v socat >/dev/null 2>&1 || return 0' \
-        '  socat -u OPEN:/dev/null UNIX-CONNECT:"$1" >/dev/null 2>&1' \
+        '  timeout 2 socat -u OPEN:/dev/null UNIX-CONNECT:"$1" >/dev/null 2>&1' \
         '}' \
         'for sock in $(ls -t /tmp/vscode-ipc-*.sock 2>/dev/null); do' \
         '  if ipc_live "$sock"; then' \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -201,6 +201,31 @@ RUN curl -sS https://downloads.1password.com/linux/keys/1password.asc | \
 
 RUN mkdir -p /home/vscode/.vscode-server/data/Machine/ && echo '{"workbench.colorTheme": "VS Code Dark"}' > /home/vscode/.vscode-server/data/Machine/settings.json
 
+# The apt `code` package installs the desktop (Electron) binary at /usr/bin/code.
+# In these headless serve-web/tunnel sessions there is no X display, so running
+# `code <file>` in the terminal crashes ("Missing X server or $DISPLAY").
+# Drop a wrapper on $HOME/.local/bin (first on the interactive PATH, see .zshrc/.bashrc
+# below) that forwards to the serve-web/remote-cli shim, which opens files in the
+# already-running VS Code window via $VSCODE_IPC_HOOK_CLI. Picks the newest shim so it
+# keeps working across VS Code updates. Only affects interactive shells; build-time
+# `code --install-extension` above still resolves to /usr/bin/code.
+RUN mkdir -p /home/vscode/.local/bin \
+    && printf '%s\n' \
+        '#!/usr/bin/env sh' \
+        '# Route `code` to the VS Code serve-web/remote CLI shim instead of the GUI desktop' \
+        '# binary (/usr/bin/code), which has no display in this container and crashes.' \
+        'shim=$(ls -t "$HOME"/.vscode/cli/serve-web/*/bin/remote-cli/code \' \
+        '              "$HOME"/.vscode-server/bin/*/bin/remote-cli/code \' \
+        '              "$HOME"/.vscode-server/cli/servers/*/server/bin/remote-cli/code \' \
+        '              2>/dev/null | head -n1)' \
+        'if [ -n "$shim" ]; then' \
+        '  exec "$shim" "$@"' \
+        'fi' \
+        'echo "code: no VS Code remote CLI shim found; is a serve-web/remote session running?" >&2' \
+        'exit 1' \
+        > /home/vscode/.local/bin/code \
+    && chmod +x /home/vscode/.local/bin/code
+
 # Add backup warning to .zshrc for vscode user
 RUN echo '\n# === Backup & Git Reminder ===' | tee -a /home/vscode/.zshrc && \
     echo 'echo -e "\e[1;31m⚠️  WARNING: No backups are configured. You are responsible for any data loss.\e[0m"' | tee -a /home/vscode/.zshrc && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -217,13 +217,15 @@ RUN mkdir -p /home/vscode/.local/bin \
         '# binary (/usr/bin/code), which has no display in this container and crashes.' \
         '' \
         '# 1. Locate the remote CLI shim. There is one per installed VS Code build, and the' \
-        '#    path embeds a build hash, so pick the newest to survive VS Code updates.' \
+        '#    path embeds a build hash, so pick the newest to survive VS Code updates. The' \
+        '#    -x check turns a found-but-not-executable match into the friendly error below' \
+        '#    instead of an opaque `exec: Permission denied`.' \
         'shim=$(ls -t "$HOME"/.vscode/cli/serve-web/*/bin/remote-cli/code \' \
         '              "$HOME"/.vscode-server/bin/*/bin/remote-cli/code \' \
         '              "$HOME"/.vscode-server/cli/servers/*/server/bin/remote-cli/code \' \
         '              2>/dev/null | head -n1)' \
-        'if [ -z "$shim" ]; then' \
-        '  echo "code: no VS Code remote CLI shim found; is a serve-web/remote session running?" >&2' \
+        'if [ -z "$shim" ] || [ ! -x "$shim" ]; then' \
+        '  echo "code: no usable VS Code remote CLI shim found; is a serve-web/remote session running?" >&2' \
         '  exit 1' \
         'fi' \
         '' \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -206,23 +206,44 @@ RUN mkdir -p /home/vscode/.vscode-server/data/Machine/ && echo '{"workbench.colo
 # `code <file>` in the terminal crashes ("Missing X server or $DISPLAY").
 # Drop a wrapper on $HOME/.local/bin (first on the interactive PATH, see .zshrc/.bashrc
 # below) that forwards to the serve-web/remote-cli shim, which opens files in the
-# already-running VS Code window via $VSCODE_IPC_HOOK_CLI. Picks the newest shim so it
-# keeps working across VS Code updates. Only affects interactive shells; build-time
+# already-running VS Code window via the $VSCODE_IPC_HOOK_CLI socket. The wrapper picks
+# the newest shim so it survives VS Code updates, and recovers from a stale socket after
+# a reconnect (see the inline comments). Only affects interactive shells; build-time
 # `code --install-extension` above still resolves to /usr/bin/code.
 RUN mkdir -p /home/vscode/.local/bin \
     && printf '%s\n' \
         '#!/usr/bin/env sh' \
         '# Route `code` to the VS Code serve-web/remote CLI shim instead of the GUI desktop' \
         '# binary (/usr/bin/code), which has no display in this container and crashes.' \
+        '' \
+        '# 1. Locate the remote CLI shim. There is one per installed VS Code build, and the' \
+        '#    path embeds a build hash, so pick the newest to survive VS Code updates.' \
         'shim=$(ls -t "$HOME"/.vscode/cli/serve-web/*/bin/remote-cli/code \' \
         '              "$HOME"/.vscode-server/bin/*/bin/remote-cli/code \' \
         '              "$HOME"/.vscode-server/cli/servers/*/server/bin/remote-cli/code \' \
         '              2>/dev/null | head -n1)' \
-        'if [ -n "$shim" ]; then' \
-        '  exec "$shim" "$@"' \
+        'if [ -z "$shim" ]; then' \
+        '  echo "code: no VS Code remote CLI shim found; is a serve-web/remote session running?" >&2' \
+        '  exit 1' \
         'fi' \
-        'echo "code: no VS Code remote CLI shim found; is a serve-web/remote session running?" >&2' \
-        'exit 1' \
+        '' \
+        '# 2. The shim talks to the running window over the IPC socket named in' \
+        '#    $VSCODE_IPC_HOOK_CLI. That value is captured when the shell starts, so after a' \
+        '#    VS Code reconnect (container or server restart) it can name a socket that no' \
+        '#    longer exists. Only when the referenced socket is gone, fall back to the most' \
+        '#    recently created /tmp/vscode-ipc-*.sock so `code` keeps working without opening' \
+        '#    a fresh terminal. A still-present socket is left untouched, so routing stays' \
+        '#    correct when multiple windows (each with its own socket) are connected.' \
+        'if [ -z "$VSCODE_IPC_HOOK_CLI" ] || [ ! -S "$VSCODE_IPC_HOOK_CLI" ]; then' \
+        '  newest_sock=$(ls -t /tmp/vscode-ipc-*.sock 2>/dev/null | head -n1)' \
+        '  if [ -n "$newest_sock" ]; then' \
+        '    VSCODE_IPC_HOOK_CLI="$newest_sock"' \
+        '    export VSCODE_IPC_HOOK_CLI' \
+        '  fi' \
+        'fi' \
+        '' \
+        '# 3. Hand off to the shim, preserving every argument and its exit status.' \
+        'exec "$shim" "$@"' \
         > /home/vscode/.local/bin/code \
     && chmod +x /home/vscode/.local/bin/code
 


### PR DESCRIPTION
## Problem

`code <file>` from the integrated terminal fails two ways in this serve-web environment:

1. **Crash.** `code` resolves to the desktop Electron binary `/usr/bin/code`, which needs an X display and dies with `Missing X server or $DISPLAY`.
2. **Silent no-op in tmux.** A tmux server started in an earlier session freezes `$VSCODE_IPC_HOOK_CLI` at an **old window's** socket. That socket still accepts connections, so `code` "succeeds" but opens the file in a window you can no longer see.

## Fix

A wrapper at `$HOME/.local/bin/code` (first on the interactive `PATH`) that forwards to the serve-web remote-cli shim. It:

1. **Resolves the newest shim** (`ls -t`, survives VS Code updates; `-x` guard → clear error instead of opaque `exec` failure).
2. **Routes to the newest live window socket.** VS Code makes one socket per window/connection under `/tmp`; the newest live one is your current window. A `socat` connect probe (bounded by `timeout 2` so `code` can never hang) skips dead sockets left by restarts; if nothing is reachable the inherited value passes through so socket-less commands still work.
3. **Passes `tunnel`/`serve-web` through to `/usr/bin/code`** — these are full-CLI subcommands the remote-cli shim doesn't implement (it would treat `tunnel` as a filename). Uses the absolute path to avoid recursing into the wrapper.

`socat` is added to the image for the probe. Only affects interactive shells — build-time `code --install-extension` runs under `/bin/sh` (no `~/.local/bin` on `PATH`) and still uses `/usr/bin/code`.

### Known limitation

With multiple windows open at once, "newest socket" may not be the exact window you typed in — serve-web exposes no API to map a socket to a window (`--status` is unsupported in browsers; every live socket answers a connect). This is the best available heuristic and matches community practice (vinnie/tmux, chvolkmann/code-connect); it is correct for the common single-window and stale-tmux cases. Documented inline in the wrapper.

## Review & validation

Reviewed by four independent experts (POSIX sh/dash, Linux/sockets, VS Code serve-web internals, Docker build) — no blocking issues; their fixes (executability guard, probe timeout, tunnel/serve-web passthrough) are folded in.

Validated against a **full `devcontainer build` of this image**, exercised via `docker exec`:

- Wrapper in the built image is byte-identical to the reviewed script; `sh -n` clean; `code` resolves to it via `.bashrc`.
- `code tunnel --help` / `code serve-web --help` → real tunnel/serve-web help (exit 0).
- No serve-web session → friendly "no usable shim" error (exit 1); never hits the GUI crash path.
- Socket selection (planted stub sockets): **skips a dead-but-newest socket, picks the newest live one, overrides a stale inherited `VSCODE_IPC_HOOK_CLI` (the tmux fix), and falls through without hanging when nothing is live.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)