### PR TITLE
feat: disable VS Code Workspace Trust in the image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -199,7 +199,10 @@ RUN curl -sS https://downloads.1password.com/linux/keys/1password.asc | \
   sudo gpg --dearmor --output /usr/share/debsig/keyrings/AC2D62742012EA22/debsig.gpg && \
   sudo apt update && sudo apt install 1password-cli
 
-RUN mkdir -p /home/vscode/.vscode-server/data/Machine/ && echo '{"workbench.colorTheme": "VS Code Dark"}' > /home/vscode/.vscode-server/data/Machine/settings.json
+# Disable VS Code Workspace Trust so folders (e.g. /workspaces/glueops) always open
+# trusted -- no "Do you trust the authors..." prompt blocking terminals/tasks on launch.
+# These are ephemeral CDEs that only ever open the user's own GlueOps repos.
+RUN mkdir -p /home/vscode/.vscode-server/data/Machine/ && echo '{"workbench.colorTheme": "VS Code Dark", "security.workspace.trust.enabled": false}' > /home/vscode/.vscode-server/data/Machine/settings.json
 
 # The apt `code` package installs the desktop (Electron) binary at /usr/bin/code.
 # In these headless serve-web/tunnel sessions there is no X display, so running


### PR DESCRIPTION
## Problem

On every codespace launch the workspace opens in **Restricted Mode** and VS Code blocks the terminal with:

> Do you trust the authors of the files in this folder?
> Creating a terminal process requires executing code

This is VS Code **Workspace Trust** gating terminals/tasks in an untrusted folder (e.g. `/workspaces/glueops`).

## Fix

Ship `"security.workspace.trust.enabled": false` in the image's Machine settings (Dockerfile L202), which already sets the color theme. This disables Workspace Trust entirely, so every folder opens trusted with no prompt.

```jsonc
{"workbench.colorTheme": "VS Code Dark", "security.workspace.trust.enabled": false}
```

## Why disable, not pre-trust one folder

VS Code stores the trusted-folder list in SQLite global state (`state.vscdb`), not in `settings.json`, and a freshly launched CDE doesn't carry it — so a specific folder can't be pre-trusted declaratively. Disabling the feature is the only reliable image-level option.

## Trade-off

Workspace Trust exists to stop a maliciously-crafted repo from auto-executing code on open. Turning it off globally means any folder opened in these CDEs runs fully trusted. Acceptable here since these ephemeral environments only ever open the user's own GlueOps repos.

Independent of #519 (the `code` CLI wrapper); both touch `.devcontainer/Dockerfile` L202 but different lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)