### PR TITLE
fix: set a restart policy on the codespace container

### DIFF
--- a/developer-setup.sh
+++ b/developer-setup.sh
@@ -284,6 +284,7 @@ dev() {
 
         if ! gum spin --spinner dot --title "Creating container '$CONTAINER_NAME'..." --show-output -- \
             sudo docker run -itd --name "$CONTAINER_NAME" \
+                --restart=unless-stopped \
                 --net=host \
                 --cap-add=SYS_PTRACE \
                 --security-opt seccomp=unconfined \


### PR DESCRIPTION
## What

Adds `--restart=unless-stopped` to the `docker run` that creates the `codespace` container in `dev` (`developer-setup.sh:287`). One line.

## Why

The container is created with no `--restart` flag, so `RestartPolicy` is `"no"` and nothing brings the environment back if its main process exits. The only recovery path is `launch-dev.service`, which is `Type=oneshot` with `RemainAfterExit=true` — it fires once at boot and never again. Mid-session there is no recovery short of re-running `dev` by hand.

This came out of investigating a CDE that went down unexpectedly. That particular incident was a `docker rm -f` (see below — this PR does **not** fix that), but the investigation surfaced that the container had no restart policy at all, which is worth closing regardless.

## What it covers

- The container's PID 1 exiting on its own
- An accidental `docker attach codespace` + <kbd>Ctrl-D</kbd> — today that takes the entire environment down
- `dockerd` crashing or being restarted

## What it deliberately does not cover

- **`docker rm -f`** — the container object is gone, so there is nothing left to restart. The writable layer (everything outside the `/workspaces/glueops` bind mount) goes with it.
- **`docker kill`** — Docker records API-initiated SIGKILLs as manual stops, which suppresses the policy for both `always` and `unless-stopped`.

## Why `unless-stopped` rather than `always`

So a deliberate `docker stop` is not undone by a later reboot. Boot recovery is unaffected either way, since `launch-dev.service` runs `dev`, which starts an existing stopped container.

## Testing

Verified against a live daemon with throwaway alpine containers (all cleaned up):

| Scenario | Result |
| --- | --- |
| Process exits on its own | `status=running restartcount=2` — restarts |
| `docker kill` | `status=exited restartcount=0` — no restart |
| `docker rm -f` | `no such object` — nothing to restart |

`bash -n developer-setup.sh` is clean. The flag was also applied to a live container with `docker update` and confirmed to take effect without bouncing it (`StartedAt` unchanged).

## Rollout caveat

This only takes effect for VMs built from a **new image**, since `dev` is snapshotted into `/home/vscode/.glueopsrc` via `declare -f` at Packer build time. Existing VMs keep their old copy of the function and can be patched in place with:

```bash
sudo docker update --restart=unless-stopped codespace
```

## Still open

Persistence is not addressed here. Everything outside the `/workspaces/glueops` bind mount lives in the container's writable layer, and `/var/run/docker.sock` is bind-mounted read-write with `vscode` in the host docker group — so any process inside the container can still `docker rm -f` the container it is running in, with no sudo and no host-side audit trail, and take the home directory (`~/.claude`, `~/.kube`, `~/.config/gh`, shell history) with it. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
