### PR TITLE
feat: load env vars into dev container via --env-file #minor

### DIFF
--- a/developer-setup.sh
+++ b/developer-setup.sh
@@ -75,8 +75,8 @@ gum --version
 sudo tee /etc/systemd/system/launch-dev.service > /dev/null <<'EOF'
 [Unit]
 Description=Call dev function from .glueopsrc
-After=network-online.target docker.service
-Wants=network-online.target
+After=network-online.target docker.service cloud-final.service
+Wants=network-online.target cloud-final.service
 
 [Service]
 Type=oneshot
@@ -282,6 +282,15 @@ dev() {
         gum style --padding "0 1" --foreground=226 \
             "🧼 Creating and starting new container '$CONTAINER_NAME' with tag $(gum style --bold "$CONTAINER_TAG_TO_USE")..."
 
+        # Guarantee the env-file exists so `docker run --env-file` never errors.
+        # This is idempotent and non-truncating: if cloud-init (or an operator)
+        # already wrote KEY=VALUE lines here, they are preserved; if the file is
+        # absent it is created empty (docker treats an empty file as zero vars).
+        # The SAME docker run command below works whether the file is empty or populated.
+        sudo mkdir -p /etc/glueops
+        sudo touch /etc/glueops/codespace.env
+        sudo chmod 600 /etc/glueops/codespace.env
+
         if ! gum spin --spinner dot --title "Creating container '$CONTAINER_NAME'..." --show-output -- \
             sudo docker run -itd --name "$CONTAINER_NAME" \
                 --net=host \
@@ -294,6 +303,7 @@ dev() {
                 -v /workspaces/glueops:/workspaces/glueops \
                 -v /var/run/docker.sock:/var/run/docker.sock \
                 -v /var/run/tailscale/tailscaled.sock:/var/run/tailscale/tailscaled.sock \
+                --env-file /etc/glueops/codespace.env \
                 -w /workspaces/glueops \
                 "ghcr.repo.gpkg.io/glueops/codespaces:${CONTAINER_TAG_TO_USE}" bash; then
              gum style --padding "0 1" --foreground=196 --bold \


### PR DESCRIPTION
## What

Adds an `--env-file` flag to the dev-container startup so environment values can be injected at container creation, using the **same run command regardless of whether the file has values**.

## Changes (all in `developer-setup.sh`)

- **`--env-file /etc/glueops/codespace.env`** added to the `docker run` in `dev()`.
- **File-existence guarantee** right before the fresh run: `mkdir -p` + `touch` + `chmod 600`. It's idempotent and **non-truncating** — a deploy-time cloud-init that wrote `KEY=VALUE` lines is preserved; if nothing wrote it, it's created empty and Docker treats an empty `--env-file` as zero vars. Container comes up either way.
- **`launch-dev.service` ordering**: `After=`/`Wants=cloud-final.service` so a deploy-time cloud-init finishes writing values before the container is created.

## Scope

Targets **new VM creation**. On first boot there's no pre-existing container, so `dev()` takes the fresh `docker run` path and reads the env file at create time. The build/Packer cloud-init is intentionally left untouched — values are supplied by a separate deploy-time cloud-init at `/etc/glueops/codespace.env`.

## Notes for consumers

- `--env-file` uses Docker's own parser (not a shell): plain `KEY=VALUE`, one per line, no quotes (kept literally), no `export`, no `$VAR` expansion.
- Env is baked at container **create** time; `docker start` of an existing container does not re-read the file. Fine for the new-VM flow.
- File is `root:root 0600` (read by `sudo docker` as root, not the container user).

## Review

Reviewed by Docker, systemd-ordering, systemd-unit, and Linux passes — no critical/high-severity defects. The `Wants=cloud-final.service` addition came out of that review to make the ordering a hard guarantee rather than ordering-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)