### PR TITLE
feat: bake build metadata into the image as env vars #minor

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -286,5 +286,21 @@ RUN echo '\n# === Backup & Git Reminder ===' | tee -a /home/vscode/.zshrc && \
 USER root
 RUN mkdir -p /home/vscode/.kube && chmod 0700 /home/vscode/.kube
 RUN chown -R vscode:vscode /home/vscode
+
+# Build metadata baked into the image as env vars (available in any run path,
+# including the plain `docker run` in developer-setup.sh -- not just when the
+# image is launched as a devcontainer). Values are supplied as build args by
+# .github/workflows/build_and_publish_devcontainer.yml via devcontainer.json.
+# Kept at the very end of the build so these per-commit values don't invalidate
+# the cache of the (expensive) tool-install layers above.
+ARG COMMIT_SHA=UNKNOWN
+ARG SHORT_SHA=UNKNOWN
+ARG BUILD_TIMESTAMP=UNKNOWN
+ARG GIT_REF=UNKNOWN
+ENV COMMIT_SHA=${COMMIT_SHA}
+ENV SHORT_SHA=${SHORT_SHA}
+ENV BUILD_TIMESTAMP=${BUILD_TIMESTAMP}
+ENV GIT_REF=${GIT_REF}
+
 ENTRYPOINT [ "/usr/local/share/docker-init.sh" ]
 CMD [ "sleep", "infinity" ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,10 +3,19 @@
 {
 	"name": "Ubuntu",
 	"build": {
-		"dockerfile": "Dockerfile"
+		"dockerfile": "Dockerfile",
+		// Build metadata forwarded to the Dockerfile as build args, sourced from
+		// the runner environment set in build_and_publish_devcontainer.yml.
+		// Default to empty locally (Dockerfile ARGs fall back to UNKNOWN).
+		"args": {
+			"COMMIT_SHA": "${localEnv:COMMIT_SHA}",
+			"SHORT_SHA": "${localEnv:SHORT_SHA}",
+			"BUILD_TIMESTAMP": "${localEnv:BUILD_TIMESTAMP}",
+			"GIT_REF": "${localEnv:GIT_REF}"
+		}
 		// Update 'VARIANT' to pick an Ubuntu version: jammy / ubuntu-22.04, focal / ubuntu-20.04, bionic /ubuntu-18.04
 		// Use ubuntu-22.04 or ubuntu-18.04 on local arm64/Apple Silicon.
-	
+
 	},
 
 	// Set *default* container specific settings.json values on container create.

--- a/.github/workflows/build_and_publish_devcontainer.yml
+++ b/.github/workflows/build_and_publish_devcontainer.yml
@@ -33,6 +33,12 @@ jobs:
       - name: Generate Variables for Tags
         uses: rlespinasse/github-slug-action@e6f261660910b273384c5c42b17a0217881b217a # v5.6.0
 
+      - name: Set build variables
+        id: vars
+        run: |
+          echo "short_sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+          echo "build_timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
+
       - name: Build and run dev container task
         uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3
         with:
@@ -41,3 +47,7 @@ jobs:
           push: always
         env:
           VERSION: "${{ env.GITHUB_REF_SLUG }}"
+          COMMIT_SHA: "${{ github.sha }}"
+          SHORT_SHA: "${{ steps.vars.outputs.short_sha }}"
+          BUILD_TIMESTAMP: "${{ steps.vars.outputs.build_timestamp }}"
+          GIT_REF: "${{ github.ref_name }}"


### PR DESCRIPTION
## What

Bakes build-provenance values into the devcontainer image as env vars, so a running container can report exactly which build it came from — mirroring the pattern in [GlueOps/tools-api](https://github.com/GlueOps/tools-api/blob/main/.github/workflows/container_image.yaml#L49-L71).

Adds: `COMMIT_SHA`, `SHORT_SHA`, `BUILD_TIMESTAMP`, `GIT_REF`.
`VERSION` is intentionally left untouched (already wired via `containerEnv`).

## How (differs from tools-api's mechanism)

tools-api uses `docker/build-push-action` with a `build-args` input. This repo builds with **`devcontainers/ci`**, which has no `build-args` input — build args are declared in `devcontainer.json` under `build.args`. So:

- **`.devcontainer/Dockerfile`** — declare the four `ARG`s (default `UNKNOWN`) and persist them as `ENV`. Placed at the **end** of the Dockerfile so these per-commit values don't invalidate the layer cache of the expensive tool-install steps above.
- **`.devcontainer/devcontainer.json`** — forward the values via `build.args` using `${localEnv:...}` (the same substitution the existing `VERSION` `containerEnv` already relies on).
- **`build_and_publish_devcontainer.yml`** — add a `vars` step computing `short_sha` + `build_timestamp`, and set the four values on the build step's `env:`.

## Value → source

| Var | Source |
|---|---|
| `COMMIT_SHA` | `github.sha` |
| `SHORT_SHA` | `${GITHUB_SHA::7}` |
| `BUILD_TIMESTAMP` | `date -u +%Y-%m-%dT%H:%M:%SZ` |
| `GIT_REF` | `github.ref_name` |

## Why ENV (not containerEnv)

Baking as image `ENV` makes the values visible in **every** run path — including the plain `sudo docker run` in `developer-setup.sh`, which does not read `devcontainer.json` `containerEnv`. Local `devcontainer build` without these set still works (ARGs fall back to `UNKNOWN`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)