### PR TITLE
feat: disable VS Code Workspace Trust for code serve-web

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -289,6 +289,11 @@ RUN echo '\n# === Backup & Git Reminder ===' | tee -a /home/vscode/.zshrc && \
 # faster first connection. Only affects the `code serve-web` path (not `code tunnel`).
 # The tool is intentionally non-fatal (dev() re-runs it at runtime), so assert here that the
 # shim actually landed — the build MUST fail if the pre-bake didn't produce a shimmed server.
+#
+# IF THIS `RUN` FAILS: the pre-bake didn't produce a shimmed bin/code-server — usually a VS
+# Code version bump changed the server. See the "IF THIS BREAKS" troubleshooting block in
+# .devcontainer/tools/cde-trust-serve-web.sh for the exact checks (launcher shape, the flag,
+# the workbench gate) and how to fix it.
 RUN cde-trust-serve-web \
     && grep -q 'cde-trust-serve-web shim' /home/vscode/.vscode/cli/serve-web/*/bin/code-server
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -283,6 +283,15 @@ RUN echo '\n# === Backup & Git Reminder ===' | tee -a /home/vscode/.zshrc && \
     echo 'export PATH="$HOME/.local/bin:$HOME/.krew/bin:$PATH"' | tee -a /home/vscode/.zshrc /home/vscode/.bashrc && \
     chown vscode:vscode /home/vscode/.zshrc /home/vscode/.bashrc
 
+# Pre-download the `code serve-web` server and shim it to disable VS Code Workspace Trust
+# (cde-trust-serve-web) so the CDE's first browser connection is prompt-free with no runtime
+# download. Baking it here (vs front-loading at `dev` time) trades a bigger image for a
+# faster first connection. Only affects the `code serve-web` path (not `code tunnel`).
+# The tool is intentionally non-fatal (dev() re-runs it at runtime), so assert here that the
+# shim actually landed — the build MUST fail if the pre-bake didn't produce a shimmed server.
+RUN cde-trust-serve-web \
+    && grep -q 'cde-trust-serve-web shim' /home/vscode/.vscode/cli/serve-web/*/bin/code-server
+
 USER root
 RUN mkdir -p /home/vscode/.kube && chmod 0700 /home/vscode/.kube
 RUN chown -R vscode:vscode /home/vscode

--- a/.devcontainer/tools/cde-trust-serve-web.sh
+++ b/.devcontainer/tools/cde-trust-serve-web.sh
@@ -59,6 +59,13 @@ set -u
 SW="$HOME/.vscode/cli/serve-web"
 SHIM_MARK='cde-trust-serve-web shim'
 
+# Everything here assumes HOME=/home/vscode — where the image bakes the server and where
+# serve-web downloads it. If the container runs as a uid without that home (the image is
+# built for uid 1337 / user `vscode`), the baked+shimmed server isn't found and the trust
+# prompt silently returns. Warn loudly so that's easy to spot rather than a mystery.
+[ "$HOME" = "/home/vscode" ] || \
+    echo "cde-trust-serve-web: WARNING: HOME=$HOME (expected /home/vscode); shim may not take effect" >&2
+
 # Remove any temp file we might leave behind if interrupted mid-write (PID-scoped).
 trap 'rm -f "$SW"/*/bin/code-server.tmp."$$" 2>/dev/null || true' EXIT
 
@@ -98,7 +105,10 @@ if ! server_present; then
     dl=$!
     port=""
     for _ in $(seq 1 30); do
-        port="$(grep -oE 'http://127\.0\.0\.1:[0-9]+' "$log" 2>/dev/null | head -1 | grep -oE '[0-9]+$')"
+        # Parse the port from serve-web's "Web UI available at http://<host>:<port>" banner.
+        # (If a VS Code version changes this wording, port stays empty -> download is skipped
+        #  -> the build assertion fails / runtime no-ops. See the "IF THIS BREAKS" block.)
+        port="$(grep -oE 'http://(127\.0\.0\.1|localhost):[0-9]+' "$log" 2>/dev/null | head -1 | grep -oE '[0-9]+$')"
         [ -n "$port" ] && break
         sleep 1
     done
@@ -110,6 +120,9 @@ if ! server_present; then
             sleep 1
         done
     fi
+    # Killing the timeout parent SIGTERMs `code serve-web`, which supervises and tears down
+    # the node server it spawned — verified in a fresh image that no serve-web/node process
+    # is left behind, so a group-kill isn't needed here.
     kill "$dl" 2>/dev/null || true
     wait "$dl" 2>/dev/null || true
     rm -f "$log"

--- a/.devcontainer/tools/cde-trust-serve-web.sh
+++ b/.devcontainer/tools/cde-trust-serve-web.sh
@@ -5,7 +5,7 @@
 # In that mode the usual ways to disable Workspace Trust do NOT work:
 #   - user settings live in the browser, so a server-side settings.json is ignored for the
 #     application-scoped `security.workspace.trust.enabled`;
-#   - `product.json` `configurationDefaults` don't reach the browser either;
+#   - `product.json` `configurationDefaults` don't reach the browser workbench;
 #   - `code serve-web` refuses to forward the server's `--disable-workspace-trust` flag
 #     ("unexpected argument").
 #
@@ -19,8 +19,10 @@
 # for every folder — without reading any setting. Idempotent and non-fatal.
 #
 # Called from developer-setup.sh's `dev` before `code serve-web` launches. The serve-web
-# server is downloaded lazily on first use, so if it isn't present yet we front-load the
-# download (then stop it) so the very first connection is prompt-free too.
+# SERVER (server-main.js) is downloaded lazily on the first browser CONNECTION, not at
+# `serve-web` startup — so if it isn't present yet we briefly start serve-web and poke its
+# port with curl to trigger the download, then patch. That makes even the first real
+# connection prompt-free.
 
 set -u
 
@@ -28,21 +30,46 @@ SW="$HOME/.vscode/cli/serve-web"
 NEEDLE='enableWorkspaceTrust:!this._environmentService.args["disable-workspace-trust"]'
 SEDEXPR='s/enableWorkspaceTrust:!this\._environmentService\.args\["disable-workspace-trust"\]/enableWorkspaceTrust:false/g'
 
-# Ensure the serve-web server is downloaded so there's a server-main.js to patch.
-if ! ls "$SW"/*/out/server-main.js >/dev/null 2>&1; then
-    echo "cde-trust-serve-web: serve-web server not present; downloading it first…"
-    timeout 180 code serve-web --accept-server-license-terms --without-connection-token --port 0 >/dev/null 2>&1 &
+# True when a fully-extracted server exists (ignore the transient "<hash>.staging" dir).
+server_present() {
+    local f
+    for f in "$SW"/*/out/server-main.js; do
+        case "$f" in *".staging/"*) continue ;; esac
+        [ -f "$f" ] && return 0
+    done
+    return 1
+}
+
+if ! server_present; then
+    echo "cde-trust-serve-web: serve-web server not present; triggering its download…"
+    log="$(mktemp)"
+    timeout 240 code serve-web --accept-server-license-terms --without-connection-token \
+        --host 127.0.0.1 --port 0 >"$log" 2>&1 &
     dl=$!
-    for _ in $(seq 1 180); do
-        ls "$SW"/*/out/server-main.js >/dev/null 2>&1 && break
+    # Discover the random port serve-web picked.
+    port=""
+    for _ in $(seq 1 30); do
+        port="$(grep -oE 'http://127\.0\.0\.1:[0-9]+' "$log" 2>/dev/null | head -1 | grep -oE '[0-9]+$')"
+        [ -n "$port" ] && break
         sleep 1
     done
-    kill "$dl" >/dev/null 2>&1 || true
+    # The server downloads lazily on the first HTTP hit — poke it until server-main.js lands.
+    if [ -n "$port" ]; then
+        for _ in $(seq 1 180); do
+            curl -fsS -o /dev/null "http://127.0.0.1:$port/" 2>/dev/null || true
+            server_present && break
+            sleep 1
+        done
+    fi
+    kill "$dl" 2>/dev/null || true
     wait "$dl" 2>/dev/null || true
+    rm -f "$log"
+    sleep 2   # let extraction/rename settle
 fi
 
 changed=0
 for f in "$SW"/*/out/server-main.js; do
+    case "$f" in *".staging/"*) continue ;; esac
     [ -f "$f" ] || continue
     if grep -qF "$NEEDLE" "$f"; then
         if sed -i "$SEDEXPR" "$f"; then

--- a/.devcontainer/tools/cde-trust-serve-web.sh
+++ b/.devcontainer/tools/cde-trust-serve-web.sh
@@ -20,7 +20,39 @@
 # startup — so to have the shim in place before that first connection (and avoid a one-time
 # prompt), we front-load the download here: briefly start serve-web on a local port and hit
 # it once (this is the same download that would happen on first connect, just moved earlier).
-# Called from developer-setup.sh's `dev` before `code serve-web` launches.
+#
+# WHERE THIS RUNS: (1) at IMAGE BUILD — .devcontainer/Dockerfile runs this and then asserts
+# the shim landed, so the build fails if it didn't; (2) at RUNTIME — developer-setup.sh's
+# `dev` calls it before `code serve-web` (a no-op when the baked server is already shimmed;
+# re-shims if a VS Code update pulled a new server).
+#
+# ─────────────────────────────────────────────────────────────────────────────────────────
+# IF THIS BREAKS (trust prompt returns, OR the Dockerfile build assertion fails): it almost
+# always means a VS Code version bump changed something below. Re-check these three facts
+# against the downloaded server at ~/.vscode/cli/serve-web/<hash>/ and update the matching
+# piece (or re-derive from the workbench source):
+#
+#   1. LAUNCHER SHAPE — we shim `bin/code-server`, which must still be a shell wrapper ending
+#      in `"$ROOT/node" ... "$ROOT/out/server-main.js" "$@"`.
+#        tail -3 ~/.vscode/cli/serve-web/*/bin/code-server.orig
+#      If the path/shape changed, update SW / the glob / the shim in this file.
+#
+#   2. THE FLAG STILL WORKS — server-main.js must still set enableWorkspaceTrust from the arg:
+#        grep -o 'enableWorkspaceTrust[^,]*' ~/.vscode/cli/serve-web/*/out/server-main.js
+#      Expect: enableWorkspaceTrust:!...args["disable-workspace-trust"]
+#
+#   3. THE WORKBENCH STILL GATES ON IT — web build must still short-circuit:
+#      isWorkspaceTrustEnabled = disableWorkspaceTrust ? false : <config>, and
+#      disableWorkspaceTrust   = !options.enableWorkspaceTrust
+#        f=~/.vscode/cli/serve-web/*/out/vs/workbench/workbench.web.main.internal.js
+#        grep -o 'isWorkspaceTrustEnabled(){[^}]*}' $f
+#        grep -o 'get disableWorkspaceTrust(){[^}]*}' $f
+#      If (2)/(3) changed, the whole flag approach may no longer apply — re-derive the lever.
+#
+# Ruled-out alternatives (don't waste time retrying these — verified not to work for
+# serve-web web mode): settings.json (User or Machine), product.json configurationDefaults,
+# and passing --disable-workspace-trust to `code serve-web` (the Rust CLI rejects it).
+# ─────────────────────────────────────────────────────────────────────────────────────────
 
 set -u
 

--- a/.devcontainer/tools/cde-trust-serve-web.sh
+++ b/.devcontainer/tools/cde-trust-serve-web.sh
@@ -16,21 +16,35 @@
 # So we shim that wrapper to append the native flag — a documented flag + a stable launcher
 # script, no patching of minified server code. Idempotent and non-fatal.
 #
-# Called from developer-setup.sh's `dev` before `code serve-web` launches. Deliberately does
-# NO network / download: it only shims a server that's already on disk. The serve-web server
-# is downloaded lazily on the first browser connection, so on a brand-new container the very
-# first connection still prompts once; every `dev` after that shims it and the prompt is gone.
+# `code serve-web` downloads the server LAZILY on the first browser connection, not at
+# startup — so to have the shim in place before that first connection (and avoid a one-time
+# prompt), we front-load the download here: briefly start serve-web on a local port and hit
+# it once (this is the same download that would happen on first connect, just moved earlier).
+# Called from developer-setup.sh's `dev` before `code serve-web` launches.
 
 set -u
 
 SW="$HOME/.vscode/cli/serve-web"
 SHIM_MARK='cde-trust-serve-web shim'
 
+# Remove any temp file we might leave behind if interrupted mid-write (PID-scoped).
+trap 'rm -f "$SW"/*/bin/code-server.tmp."$$" 2>/dev/null || true' EXIT
+
+# True when a fully-extracted server wrapper exists (ignore the transient "<hash>.staging" dir).
+server_present() {
+    local f
+    for f in "$SW"/*/bin/code-server; do
+        case "$f" in *".staging/"*) continue ;; esac
+        [ -f "$f" ] && return 0
+    done
+    return 1
+}
+
 # Wrap <server>/bin/code-server so the server is always launched with --disable-workspace-trust.
 shim_one() {
     local cs="$1" orig="$1.orig" tmp
     [ -f "$cs" ] || return 1
-    grep -q "$SHIM_MARK" "$cs" 2>/dev/null && return 0     # already shimmed
+    grep -qF "$SHIM_MARK" "$cs" 2>/dev/null && return 0     # already shimmed
     [ -f "$orig" ] || cp -p "$cs" "$orig"                  # preserve the real launcher once
     tmp="$cs.tmp.$$"
     cat > "$tmp" <<'SH'
@@ -43,11 +57,38 @@ SH
     mv "$tmp" "$cs"
 }
 
+# Front-load the lazy server download so there's a wrapper to shim before the first connection.
+if ! server_present; then
+    echo "cde-trust-serve-web: serve-web server not downloaded yet; front-loading it…"
+    log="$(mktemp)"
+    timeout 240 code serve-web --accept-server-license-terms --without-connection-token \
+        --host 127.0.0.1 --port 0 >"$log" 2>&1 &
+    dl=$!
+    port=""
+    for _ in $(seq 1 30); do
+        port="$(grep -oE 'http://127\.0\.0\.1:[0-9]+' "$log" 2>/dev/null | head -1 | grep -oE '[0-9]+$')"
+        [ -n "$port" ] && break
+        sleep 1
+    done
+    # The server downloads on the first HTTP hit — poke it until the wrapper lands.
+    if [ -n "$port" ]; then
+        for _ in $(seq 1 180); do
+            curl -fsS -o /dev/null "http://127.0.0.1:$port/" 2>/dev/null || true
+            server_present && break
+            sleep 1
+        done
+    fi
+    kill "$dl" 2>/dev/null || true
+    wait "$dl" 2>/dev/null || true
+    rm -f "$log"
+    sleep 2   # let extraction/rename settle
+fi
+
 changed=0
 for cs in "$SW"/*/bin/code-server; do
-    case "$cs" in *".staging/"*) continue ;; esac   # skip the transient download dir
-    [ -f "$cs" ] || continue                          # no server downloaded yet -> nothing to do
-    grep -q "$SHIM_MARK" "$cs" 2>/dev/null && continue
+    case "$cs" in *".staging/"*) continue ;; esac
+    [ -f "$cs" ] || continue
+    grep -qF "$SHIM_MARK" "$cs" 2>/dev/null && continue
     if shim_one "$cs"; then
         echo "cde-trust-serve-web: shimmed $cs with --disable-workspace-trust"
         changed=1
@@ -55,6 +96,6 @@ for cs in "$SW"/*/bin/code-server; do
 done
 
 if [ "$changed" -eq 0 ]; then
-    echo "cde-trust-serve-web: no change (already shimmed, or server not downloaded yet)"
+    echo "cde-trust-serve-web: no change (already shimmed, or server unavailable)"
 fi
 exit 0

--- a/.devcontainer/tools/cde-trust-serve-web.sh
+++ b/.devcontainer/tools/cde-trust-serve-web.sh
@@ -1,85 +1,60 @@
 #!/usr/bin/env bash
-# cde-trust-serve-web — disable VS Code "Workspace Trust" for `code serve-web`.
+# cde-trust-serve-web — open CDE folders without the "Do you trust the authors…" prompt.
 #
 # The CDE web UI is served by `code serve-web`, which runs the workbench in the BROWSER.
-# In that mode the usual ways to disable Workspace Trust do NOT work:
-#   - user settings live in the browser, so a server-side settings.json is ignored for the
-#     application-scoped `security.workspace.trust.enabled`;
-#   - `product.json` `configurationDefaults` don't reach the browser workbench;
-#   - `code serve-web` refuses to forward the server's `--disable-workspace-trust` flag
-#     ("unexpected argument").
+# In that mode the usual ways to disable Workspace Trust don't work: user settings live in
+# the browser (a server-side settings.json is ignored for the application-scoped
+# `security.workspace.trust.enabled`), and `product.json` defaults don't reach the browser.
 #
-# The workbench decides trust with:
-#     isWorkspaceTrustEnabled = disableWorkspaceTrust ? false : <config value>
-#     disableWorkspaceTrust   = !options.enableWorkspaceTrust
-# and the server (server-main.js) sets that option from the CLI flag:
-#     enableWorkspaceTrust: !args["disable-workspace-trust"]
-# So we patch server-main.js to force `enableWorkspaceTrust:false`, which makes
-# disableWorkspaceTrust true and short-circuits the "Do you trust the authors…" prompt off
-# for every folder — without reading any setting. Idempotent and non-fatal.
+# VS Code's SERVER does support a native `--disable-workspace-trust` flag (server-main.js:
+# `enableWorkspaceTrust: !args["disable-workspace-trust"]`, which the web workbench turns
+# into `disableWorkspaceTrust`, short-circuiting the prompt off). The only catch is that the
+# `code serve-web` Rust CLI refuses to forward that flag ("unexpected argument").
 #
-# Called from developer-setup.sh's `dev` before `code serve-web` launches. The serve-web
-# SERVER (server-main.js) is downloaded lazily on the first browser CONNECTION, not at
-# `serve-web` startup — so if it isn't present yet we briefly start serve-web and poke its
-# port with curl to trigger the download, then patch. That makes even the first real
-# connection prompt-free.
+# serve-web launches the server through a small shell wrapper, `<server>/bin/code-server`,
+# which ends with:  "$ROOT/node" ... "$ROOT/out/server-main.js" "$@"
+# So we shim that wrapper to append the native flag — a documented flag + a stable launcher
+# script, no patching of minified server code. Idempotent and non-fatal.
+#
+# Called from developer-setup.sh's `dev` before `code serve-web` launches. Deliberately does
+# NO network / download: it only shims a server that's already on disk. The serve-web server
+# is downloaded lazily on the first browser connection, so on a brand-new container the very
+# first connection still prompts once; every `dev` after that shims it and the prompt is gone.
 
 set -u
 
 SW="$HOME/.vscode/cli/serve-web"
-NEEDLE='enableWorkspaceTrust:!this._environmentService.args["disable-workspace-trust"]'
-SEDEXPR='s/enableWorkspaceTrust:!this\._environmentService\.args\["disable-workspace-trust"\]/enableWorkspaceTrust:false/g'
+SHIM_MARK='cde-trust-serve-web shim'
 
-# True when a fully-extracted server exists (ignore the transient "<hash>.staging" dir).
-server_present() {
-    local f
-    for f in "$SW"/*/out/server-main.js; do
-        case "$f" in *".staging/"*) continue ;; esac
-        [ -f "$f" ] && return 0
-    done
-    return 1
+# Wrap <server>/bin/code-server so the server is always launched with --disable-workspace-trust.
+shim_one() {
+    local cs="$1" orig="$1.orig" tmp
+    [ -f "$cs" ] || return 1
+    grep -q "$SHIM_MARK" "$cs" 2>/dev/null && return 0     # already shimmed
+    [ -f "$orig" ] || cp -p "$cs" "$orig"                  # preserve the real launcher once
+    tmp="$cs.tmp.$$"
+    cat > "$tmp" <<'SH'
+#!/usr/bin/env sh
+# cde-trust-serve-web shim — pass VS Code's native --disable-workspace-trust flag to the
+# server (code serve-web won't forward it) so serve-web opens folders without the trust prompt.
+exec "$(dirname "$0")/code-server.orig" "$@" --disable-workspace-trust
+SH
+    chmod +x "$tmp"
+    mv "$tmp" "$cs"
 }
 
-if ! server_present; then
-    echo "cde-trust-serve-web: serve-web server not present; triggering its download…"
-    log="$(mktemp)"
-    timeout 240 code serve-web --accept-server-license-terms --without-connection-token \
-        --host 127.0.0.1 --port 0 >"$log" 2>&1 &
-    dl=$!
-    # Discover the random port serve-web picked.
-    port=""
-    for _ in $(seq 1 30); do
-        port="$(grep -oE 'http://127\.0\.0\.1:[0-9]+' "$log" 2>/dev/null | head -1 | grep -oE '[0-9]+$')"
-        [ -n "$port" ] && break
-        sleep 1
-    done
-    # The server downloads lazily on the first HTTP hit — poke it until server-main.js lands.
-    if [ -n "$port" ]; then
-        for _ in $(seq 1 180); do
-            curl -fsS -o /dev/null "http://127.0.0.1:$port/" 2>/dev/null || true
-            server_present && break
-            sleep 1
-        done
-    fi
-    kill "$dl" 2>/dev/null || true
-    wait "$dl" 2>/dev/null || true
-    rm -f "$log"
-    sleep 2   # let extraction/rename settle
-fi
-
 changed=0
-for f in "$SW"/*/out/server-main.js; do
-    case "$f" in *".staging/"*) continue ;; esac
-    [ -f "$f" ] || continue
-    if grep -qF "$NEEDLE" "$f"; then
-        if sed -i "$SEDEXPR" "$f"; then
-            echo "cde-trust-serve-web: disabled Workspace Trust in $f"
-            changed=1
-        fi
+for cs in "$SW"/*/bin/code-server; do
+    case "$cs" in *".staging/"*) continue ;; esac   # skip the transient download dir
+    [ -f "$cs" ] || continue                          # no server downloaded yet -> nothing to do
+    grep -q "$SHIM_MARK" "$cs" 2>/dev/null && continue
+    if shim_one "$cs"; then
+        echo "cde-trust-serve-web: shimmed $cs with --disable-workspace-trust"
+        changed=1
     fi
 done
 
 if [ "$changed" -eq 0 ]; then
-    echo "cde-trust-serve-web: no change (already patched, or server missing / pattern changed)"
+    echo "cde-trust-serve-web: no change (already shimmed, or server not downloaded yet)"
 fi
 exit 0

--- a/.devcontainer/tools/cde-trust-serve-web.sh
+++ b/.devcontainer/tools/cde-trust-serve-web.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# cde-trust-serve-web — disable VS Code "Workspace Trust" for `code serve-web`.
+#
+# The CDE web UI is served by `code serve-web`, which runs the workbench in the BROWSER.
+# In that mode the usual ways to disable Workspace Trust do NOT work:
+#   - user settings live in the browser, so a server-side settings.json is ignored for the
+#     application-scoped `security.workspace.trust.enabled`;
+#   - `product.json` `configurationDefaults` don't reach the browser either;
+#   - `code serve-web` refuses to forward the server's `--disable-workspace-trust` flag
+#     ("unexpected argument").
+#
+# The workbench decides trust with:
+#     isWorkspaceTrustEnabled = disableWorkspaceTrust ? false : <config value>
+#     disableWorkspaceTrust   = !options.enableWorkspaceTrust
+# and the server (server-main.js) sets that option from the CLI flag:
+#     enableWorkspaceTrust: !args["disable-workspace-trust"]
+# So we patch server-main.js to force `enableWorkspaceTrust:false`, which makes
+# disableWorkspaceTrust true and short-circuits the "Do you trust the authors…" prompt off
+# for every folder — without reading any setting. Idempotent and non-fatal.
+#
+# Called from developer-setup.sh's `dev` before `code serve-web` launches. The serve-web
+# server is downloaded lazily on first use, so if it isn't present yet we front-load the
+# download (then stop it) so the very first connection is prompt-free too.
+
+set -u
+
+SW="$HOME/.vscode/cli/serve-web"
+NEEDLE='enableWorkspaceTrust:!this._environmentService.args["disable-workspace-trust"]'
+SEDEXPR='s/enableWorkspaceTrust:!this\._environmentService\.args\["disable-workspace-trust"\]/enableWorkspaceTrust:false/g'
+
+# Ensure the serve-web server is downloaded so there's a server-main.js to patch.
+if ! ls "$SW"/*/out/server-main.js >/dev/null 2>&1; then
+    echo "cde-trust-serve-web: serve-web server not present; downloading it first…"
+    timeout 180 code serve-web --accept-server-license-terms --without-connection-token --port 0 >/dev/null 2>&1 &
+    dl=$!
+    for _ in $(seq 1 180); do
+        ls "$SW"/*/out/server-main.js >/dev/null 2>&1 && break
+        sleep 1
+    done
+    kill "$dl" >/dev/null 2>&1 || true
+    wait "$dl" 2>/dev/null || true
+fi
+
+changed=0
+for f in "$SW"/*/out/server-main.js; do
+    [ -f "$f" ] || continue
+    if grep -qF "$NEEDLE" "$f"; then
+        if sed -i "$SEDEXPR" "$f"; then
+            echo "cde-trust-serve-web: disabled Workspace Trust in $f"
+            changed=1
+        fi
+    fi
+done
+
+if [ "$changed" -eq 0 ]; then
+    echo "cde-trust-serve-web: no change (already patched, or server missing / pattern changed)"
+fi
+exit 0

--- a/developer-setup.sh
+++ b/developer-setup.sh
@@ -369,6 +369,10 @@ dev() {
 
     if [ -n "$CDE_TOKEN" ]; then
         AUTOSSH_PIDFILE="$PID_FILE" autossh -M 0 -f -N -o "ServerAliveInterval 30" -o "ServerAliveCountMax 3" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/sish_tunnel_key_id_ed25519 -p 2222 -l $HOSTNAME -R cde:80:localhost:8000 tunnels.glueopshosted.com
+        # Disable VS Code Workspace Trust so folders open without the "Do you trust the
+        # authors…" prompt (code serve-web is web-mode — see cde-trust-serve-web for why the
+        # usual settings don't work). Non-fatal, and a no-op on older images without the tool.
+        sudo docker exec "$CONTAINER_NAME" bash -lc 'command -v cde-trust-serve-web >/dev/null 2>&1 && cde-trust-serve-web || true' || true
         sudo docker exec -it "$CONTAINER_NAME" bash -c "code serve-web --host 0.0.0.0 --accept-server-license-terms --port 8000 --connection-token $CDE_TOKEN"
     else
         sudo docker exec -it "$CONTAINER_NAME" bash -c "code tunnel --random-name $LOG_OPTIONS"

--- a/developer-setup.sh
+++ b/developer-setup.sh
@@ -370,8 +370,10 @@ dev() {
     if [ -n "$CDE_TOKEN" ]; then
         AUTOSSH_PIDFILE="$PID_FILE" autossh -M 0 -f -N -o "ServerAliveInterval 30" -o "ServerAliveCountMax 3" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/sish_tunnel_key_id_ed25519 -p 2222 -l $HOSTNAME -R cde:80:localhost:8000 tunnels.glueopshosted.com
         # Disable VS Code Workspace Trust so folders open without the "Do you trust the
-        # authors…" prompt (code serve-web is web-mode — see cde-trust-serve-web for why the
-        # usual settings don't work). Non-fatal, and a no-op on older images without the tool.
+        # authors…" prompt. Normally a no-op (the server is baked + shimmed at image build);
+        # re-shims if a VS Code update pulled a new server. If the prompt comes back, see the
+        # "IF THIS BREAKS" block in .devcontainer/tools/cde-trust-serve-web.sh. Non-fatal, and
+        # a no-op on older images without the tool.
         sudo docker exec "$CONTAINER_NAME" bash -lc 'command -v cde-trust-serve-web >/dev/null 2>&1 && cde-trust-serve-web || true' || true
         sudo docker exec -it "$CONTAINER_NAME" bash -c "code serve-web --host 0.0.0.0 --accept-server-license-terms --port 8000 --connection-token $CDE_TOKEN"
     else


### PR DESCRIPTION
## Problem

Opening the CDE web UI (`code serve-web`) shows **"Do you trust the authors of the files in this folder?"** on every new folder — an extra click each time.

## Why the obvious fixes don't work

`code serve-web` runs the workbench in the **browser** (web mode):
- user `settings.json` lives in the browser, so a server-side `settings.json` is ignored for the **application-scoped** `security.workspace.trust.enabled` (an existing `data/Machine/settings.json` entry in the image never took effect);
- `product.json` `configurationDefaults` don't reach the browser workbench;
- `code serve-web` **rejects** the server's `--disable-workspace-trust` flag (`error: unexpected argument`).

## The fix — the native flag, via a launcher shim, baked at build time

VS Code's **server** *does* support `--disable-workspace-trust` (`server-main.js`: `enableWorkspaceTrust: !args["disable-workspace-trust"]`, which the web workbench turns into `disableWorkspaceTrust`, short-circuiting the prompt off). Only the `code serve-web` Rust CLI won't forward it.

serve-web launches the server through the shell wrapper `<server>/bin/code-server` (`… "$ROOT/node" "$ROOT/out/server-main.js" "$@"`). New tool **`cde-trust-serve-web`** (baked to `/usr/local/bin`) shims that wrapper to append `--disable-workspace-trust` — a documented flag + a stable launcher script, no patching of minified code. Idempotent (marker-gated), atomic (temp-file + `mv`), preserves the real launcher once as `code-server.orig`.

**Baked at build:** `code serve-web` downloads its server lazily on the first browser connection, so the Dockerfile pre-downloads + shims it at build time (`RUN cde-trust-serve-web`). The build **asserts** the shim landed (`grep -q` the marker) and **fails** if it didn't — the tool itself stays non-fatal for the runtime call, so the Dockerfile enforces success. Result: **single `dev`, prompt-free on the first connection, no runtime download.**

`dev()` still runs the tool before `code serve-web` launches — a no-op when the baked server is present, and a fallback that re-shims if a VS Code update downloads a new server at runtime.

## Scope

- Only affects the **`code serve-web`** path (the single-click CDE). The runtime hook is inside the `CDE_TOKEN` branch, and the tool only ever edits `~/.vscode/cli/serve-web/*/bin/code-server`.
- The **`code tunnel`** (vscode.dev) path uses a separate server under `~/.vscode-server/…` — untouched, unchanged (it keeps its current trust behavior).
- Cost: the baked server adds ~150 MB to the image (carried by all pulls, including tunnel-only users).

## Verification (real image, `docker exec` + `docker build`)

- Tool run in a fresh `ghcr.io/glueops/codespaces:v0.150.0` container: a single invocation front-loads the download and shims `bin/code-server`; serve-web then launches `server-main.js` with `--disable-workspace-trust` (confirmed via `ps`). Idempotent re-run makes no change.
- **Building `FROM` the image** (the real bake): the `RUN` layer resolves `HOME=/home/vscode`, downloads + shims in ~11s, `bin/code-server` becomes the shim with `code-server.orig` preserved (`vscode:vscode`), build succeeds.
- `bash -n` + shellcheck clean. **Shell-expert reviewed:** verdict *"minimal, clean, and reliable — ship it"* (nits applied: temp-file cleanup trap, `grep -F`).

## Notes / limitations

- If a future VS Code server changes the `bin/code-server` launcher shape, the build assertion fails loudly (and the runtime tool safely no-ops) — a signal to update the tool when the pinned VS Code version bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)