### PR TITLE
feat: open a terminal at startup instead of the welcome tab

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,16 @@
 	},
 
 	// Set *default* container specific settings.json values on container create.
-	"settings": {},
+	"customizations": {
+		"vscode": {
+			"settings": {
+				// Don't open the Welcome / Get Started tab on launch.
+				"workbench.startupEditor": "none",
+				// Don't auto-open extension walkthroughs (e.g. "Get Started with Codespaces").
+				"workbench.welcomePage.walkthroughs.openOnInstall": false
+			}
+		}
+	},
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,8 +13,9 @@
 	"customizations": {
 		"vscode": {
 			"settings": {
-				// Don't open the Welcome / Get Started tab on launch.
-				"workbench.startupEditor": "none",
+				// Open a terminal in the editor area at startup instead of the
+				// Welcome / Get Started tab.
+				"workbench.startupEditor": "terminal",
 				// Don't auto-open extension walkthroughs (e.g. "Get Started with Codespaces").
 				"workbench.welcomePage.walkthroughs.openOnInstall": false
 			}


### PR DESCRIPTION
## What

Two changes to the codespace's VS Code defaults:

1. **A terminal opens automatically** in the editor area on session start.
2. **The Welcome / Get Started tab no longer opens** — and no longer comes back on extension install.

Both live in `customizations.vscode.settings`. The existing top-level `"settings"` block was the legacy location and was empty, so nothing was lost moving off it.

| Setting | Effect |
| --- | --- |
| `workbench.startupEditor: "terminal"` | Opens a terminal at startup; also suppresses the Welcome tab, since this setting holds a single value |
| `workbench.welcomePage.walkthroughs.openOnInstall: false` | Walkthroughs don't re-open on extension install |

The second one is why the tab tends to reappear even after you close it — any extension install re-triggers its walkthrough.

## Why these are valid here

Confirmed against VS Code source, `welcomeGettingStarted/browser/gettingStarted.contribution.ts`:

- `workbench.startupEditor` is `ConfigurationScope.RESOURCE`
- `workbench.welcomePage.walkthroughs.openOnInstall` is `ConfigurationScope.MACHINE` — machine-scoped only, so a devcontainer is the right place for it

Neither is `APPLICATION`-scoped, which would have made VS Code reject them from machine settings.

Precedence is Default -> User -> Remote/Machine -> Workspace -> Folder, so these beat a teammate's Settings Sync values. No repo `.vscode/settings.json` exists to override them.

`startupPage.ts:149-151` shows `"terminal"` dispatching `TerminalCommandId.CreateTerminalEditor`.

## Caveats

- Settings are seeded into the container settings file at **create** time, so this applies to newly created or rebuilt codespaces — not ones already running.
- The startup-editor path only runs when no editors are restored from the previous session (`startupPage.ts:284`). So the terminal appears on fresh starts, not on browser reloads that restore prior state — those already restore terminals via persistent sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)