### PR TITLE
feat: upgrade Packer base to Debian 13 + add incus-agent

### DIFF
--- a/developer-setup.sh
+++ b/developer-setup.sh
@@ -24,7 +24,7 @@ curl -fsSL https://get.docker.com -o get-docker.sh
 sudo sh get-docker.sh
 sudo mkdir -p /etc/docker && echo '{"mtu": 1400}' | sudo tee /etc/docker/daemon.json > /dev/null && sudo systemctl restart docker
 sudo apt-get update
-sudo apt install tmux jq figlet qemu-guest-agent autossh ripgrep -y
+sudo apt install tmux jq figlet qemu-guest-agent incus-agent autossh ripgrep -y
 sudo apt-get clean
 sudo mkdir -p /etc/qemu
 printf '[general]\nblacklist =\n' | sudo tee /etc/qemu/qemu-ga.conf

--- a/developer-setup.sh
+++ b/developer-setup.sh
@@ -33,7 +33,8 @@ printf '[general]\nblacklist =\n' | sudo tee /etc/qemu/qemu-ga.conf
 #sudo apt-get -s dist-upgrade | grep "^Inst" | grep -i securi | awk -F " " {'print $2'} | xargs sudo apt-get install -y
 sudo groupadd -f docker
 sudo usermod -aG docker vscode
-echo 'fs.inotify.max_user_instances=1024' | sudo tee -a /etc/sysctl.conf
+# Debian 13 (trixie) systemd-sysctl no longer reads /etc/sysctl.conf; use /etc/sysctl.d/.
+echo 'fs.inotify.max_user_instances=1024' | sudo tee /etc/sysctl.d/99-glueops-codespaces.conf
 echo 1024 | sudo tee /proc/sys/fs/inotify/max_user_instances
 echo "Create .glueopsrc"
 

--- a/developer-setup.sh
+++ b/developer-setup.sh
@@ -23,7 +23,7 @@ echo "Installing other requirements now"
 curl -fsSL https://get.docker.com -o get-docker.sh
 sudo sh get-docker.sh
 sudo mkdir -p /etc/docker && echo '{"mtu": 1400}' | sudo tee /etc/docker/daemon.json > /dev/null && sudo systemctl restart docker
-sudo apt-get update
+sudo apt-get update --error-on=any
 sudo apt install tmux jq figlet qemu-guest-agent incus-agent autossh ripgrep -y
 sudo apt-get clean
 sudo mkdir -p /etc/qemu

--- a/os-setup-start.sh
+++ b/os-setup-start.sh
@@ -9,5 +9,7 @@ df -h /
 lsblk
 
 echo "update packages..."
-sudo apt-get update
+# --error-on=any: fail the build if ANY apt source errors, rather than silently
+# proceeding with a stale/partial index and shipping a subtly-broken image.
+sudo apt-get update --error-on=any
 

--- a/qemu.pkr.hcl
+++ b/qemu.pkr.hcl
@@ -8,8 +8,8 @@ variable "image_password" {
 
 source "qemu" "qemu-amd64" {
   accelerator       = "kvm"
-  iso_url           = "https://cloud.debian.org/images/cloud/bookworm/daily/latest/debian-12-generic-amd64-daily.qcow2"
-  iso_checksum      = "file:https://cloud.debian.org/images/cloud/bookworm/daily/latest/SHA512SUMS"
+  iso_url           = "https://cloud.debian.org/images/cloud/trixie/daily/latest/debian-13-generic-amd64-daily.qcow2"
+  iso_checksum      = "file:https://cloud.debian.org/images/cloud/trixie/daily/latest/SHA512SUMS"
   disk_image        = true
   output_directory  = "images"
   disk_size         = 20000


### PR DESCRIPTION
## What
- Bump the Packer **VM** base image Debian 12 (bookworm) → **Debian 13 (trixie)**, daily generic amd64 (`qemu.pkr.hcl`).
- Install the **`incus-agent`** package in `developer-setup.sh` (next to `qemu-guest-agent`).

## Why
The qcow2 VM image is now also imported and run under **Incus**. Incus manages VM guests through its **own** agent (`incus-agent`, over vsock) — `qemu-guest-agent` does **not** serve Incus. Without `incus-agent`, an Incus VM boots and runs fine but can't be shelled into, doesn't report its IP, and can't surface cloud-init status through Incus tooling. Adding it makes images built here first-class under Incus, mirroring how `qemu-guest-agent` already serves the QEMU/AWS/Hetzner paths.

## Why the Debian 13 bump is paired with it
`incus-agent` is in **Debian 13 (trixie) main** (6.0.4-2+deb13u8), but not in Debian 12 without `bookworm-backports`. Bumping the base to trixie keeps the install a plain one-liner and avoids adding a backports apt source.

## Safety / blast radius (reviewed by a Debian and a Linux/systemd expert)
- **Activation is exclusively udev-driven, and Incus-only.** `incus-agent`'s unit has **no `[Install]` section** and Debian installs it with **`--no-start`**, so it can't be enabled at boot. Its `/usr/lib/udev/rules.d/60-incus-agent.rules` matches exactly one device — the virtio-serial port `virtio-ports/org.linuxcontainers.incus`, which **only Incus** configures. On AWS/Hetzner/plain-QEMU that port never exists, so the service is never pulled into the boot transaction — it's an inert installed package there. (qemu-guest-agent uses a different port, `org.qemu.guest_agent.0`; the two are fully independent.)
- **The packaged binary is a loader.** It mounts the Incus-provided agent share at runtime and runs the **host-supplied** agent binary — so the running agent is always version-matched to the Incus host (no 6.0.4-vs-7.x skew concern).
- **Build-time safe.** `--no-start` + no `[Install]` means the postinst only does daemon/udev reload; it never starts the agent during the plain-QEMU Packer build, so `set -e` in `developer-setup.sh` stays happy.
- **Scope:** `developer-setup.sh` runs **only** in the Packer VM build (its `qemu.pkr.hcl` provisioner) — **not** in the container/Ubuntu devcontainer image — so that build is unaffected.
- **Boot:** Debian 13 generic images remain **hybrid BIOS+UEFI**, so they still boot under Incus (UEFI) and the existing QEMU/cloud targets. All 7 apt packages in the build (`tmux jq figlet qemu-guest-agent incus-agent autossh ripgrep`) are in trixie main; nothing removed/renamed.

## Debian 13 migration correctness (also in this PR)
- **`/etc/sysctl.conf` → `/etc/sysctl.d/`:** trixie's `systemd-sysctl` no longer reads `/etc/sysctl.conf` (release notes §5.1.15), so the `fs.inotify.max_user_instances` setting would have silently stopped applying. Moved to `/etc/sysctl.d/99-glueops-codespaces.conf`.
- **`apt-get update --error-on=any`:** the build now fails loudly if any apt source errors, instead of proceeding with a stale/partial index and shipping a subtly-broken image.

## Bonus from the bump
Debian 13 ships **kernel 6.12 LTS** (vs bookworm's 6.1) with better **virtio/vsock/KVM** — which directly benefits the Incus path (the agent talks over vsock).

## Release-notes review
Reviewed against the **full trixie release notes** (Ch 2/4/5) by a Debian and a Linux/systemd expert. Verdict: **no code changes required beyond the two fixes already in this PR.** Everything else in trixie is transparent for this image (Docker + `{"mtu":1400}` + cgroup-v2/iptables-nft confirmed safe; `/tmp` tmpfs harmless here since Docker data lives in `/var/lib/docker`; no nftables/containerd/vsock migration in the notes). Informational only: trixie uses deb822 `debian.sources` (nothing here parses `/etc/apt/sources.list`), and Go static binaries (Docker/incus-agent/Tailscale) get security fixes via point releases.

## Testing — the ⚠️ item is the one real build-break risk the reviewers flagged
Run the Packer build once and confirm on the built image:
1. Build completes on trixie (package availability / cloud-init).
2. ⚠️ **`get.docker.com` resolves a real `dists/trixie` Docker repo.** The convenience script derives the suite from the OS codename; early after trixie's release `download.docker.com` lacked `dists/trixie` (moby/moby#49494). If it 404s, the build fails under `set -e`. **Highest build-break risk** — likely resolved by now, but gate on it.
3. **DNS resolves on the booted image** (sanity check — low risk): `resolvectl status` shows a DNS server and it can resolve get.docker.com / tailscale.com / the GlueOps provisioner. The reported trixie cloud-init DNS bug affects **static** cloud-init IP+DNS config only (DNS is written to the loopback interface, which Debian 13's ifupdown `resolved` helper ignores) — **DHCP-provided DNS is unaffected**, and all our targets (Incus/AWS/Hetzner/QEMU) use DHCP, so this is a confirmation, not an expected failure.
4. Tailscale's `install.sh` selects the trixie apt repo, and `incus-agent` registers/serves under a real Incus launch (inert until the Incus virtio device appears).

Change itself is minimal and reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
