### PR TITLE
fix: enable cloud-init on Incus VMs

### DIFF
--- a/os-setup-finish.sh
+++ b/os-setup-finish.sh
@@ -1,6 +1,23 @@
 #!/bin/bash
 set -e -o pipefail
 
+# --- Make cloud-init run on Incus VMs -----------------------------------------
+# On Incus, cloud-init's ds-identify generator runs very early in boot — before the incus-agent
+# presents the datasource over vsock — so it finds nothing and DISABLES cloud-init
+# (`disabled-by-generator`). Result on Incus: no netplan is written, the NIC never comes up, and
+# user-data never runs. libvirt/Proxmox/QEMU don't hit this because they attach a cidata seed disk
+# that ds-identify sees immediately (the same way this Packer build's own `cd_label=cidata` works).
+#
+# This policy tells ds-identify NOT to disable cloud-init when it finds no datasource early; cloud-init
+# then discovers the LXD/Incus datasource at its normal stages (via the already-installed incus-agent).
+# It is INERT everywhere a datasource IS found early (libvirt/Proxmox/bare-metal cidata): the
+# `notfound` branch simply never triggers, so those platforms behave exactly as before.
+sudo install -d -m 0755 /etc/cloud /etc/cloud/cloud.cfg.d
+printf 'policy: search,found=all,maybe=all,notfound=enabled\n' | sudo tee /etc/cloud/ds-identify.cfg >/dev/null
+# The policy above intentionally lets cloud-init run when ds-identify reported no source, which emits a
+# cosmetic "dsid_missing_source" warning on Incus (source was [], but LXD was used). Silence just that.
+printf 'warnings:\n  dsid_missing_source: off\n' | sudo tee /etc/cloud/cloud.cfg.d/99-warnings.cfg >/dev/null
+
 echo "cleaning up"
 sudo cloud-init clean --machine-id --seed --logs
 sudo rm -rvf /var/lib/cloud/instances /etc/machine-id /var/lib/dbus/machine-id /var/log/cloud-init*


### PR DESCRIPTION
## Problem

The codespace image runs cloud-init fine on **libvirt** and **Proxmox 9**, but on **Incus** it comes up with **no network** and cloud-init reports `status: disabled` / `boot_status_code: disabled-by-generator`. So no netplan is written (the NIC stays `DOWN`), and any `cloud-init.user-data` is silently ignored.

### Root cause

On Incus VMs, cloud-init's `ds-identify` **generator runs very early in boot — before the `incus-agent` presents the datasource over vsock**. It finds no datasource and *disables cloud-init for that boot*. libvirt/Proxmox/QEMU never hit this because they attach a **cidata seed disk** that `ds-identify` sees immediately — the same mechanism this repo's own Packer build already uses (`cd_label = "cidata"`). Incus delivers config through the agent instead, which starts too late for the early check.

It's not that cloud-init is broken in the image — it's that Incus's datasource isn't visible at the instant cloud-init decides whether to run.

## Fix

Two small files written in `os-setup-finish.sh` (survive the existing `cloud-init clean`, which doesn't touch `/etc/cloud`):

- `/etc/cloud/ds-identify.cfg` → `policy: search,found=all,maybe=all,notfound=enabled` — don't disable cloud-init when nothing is found early; it then finds the LXD/Incus datasource at its normal stages via the (already-installed) `incus-agent`.
- `/etc/cloud/cloud.cfg.d/99-warnings.cfg` → silence the cosmetic `dsid_missing_source` warning the above intentionally produces on Incus.

**Inert on non-Incus:** where a seed disk *is* found early (libvirt/Proxmox/bare-metal cidata), the `notfound` branch never fires, so those platforms behave exactly as before.

## Verification — on real hardware (bare-metal Incus host + QEMU cidata boot)

Built a `debian-13-generic` image (this repo's base) with/without the change and booted it both ways:

| | Baseline (no fix) | With fix |
|---|---|---|
| **Incus VM** | `disabled-by-generator`; NIC down; **no IP**; user-data ignored | `status: done`; **DHCP lease**; **user-data runs**; `detail: DataSourceLXD`; `errors: []`; ~3s |
| **non-Incus (QEMU + cidata seed)** | cloud-init runs from seed | cloud-init still runs from seed; **user-data runs** — unchanged |

Baseline Incus (reproduced the bug):
```
status: disabled
boot_status_code: disabled-by-generator
```
With fix on Incus:
```
status: done
extended_status: done
boot_status_code: enabled-by-generator
detail: DataSourceLXD
errors: []
```
`incus list` → `RUNNING  10.19.69.178 (enp5s0)`, and the injected user-data `runcmd`/`final_message` markers all appear.

## Note
This relies on the `incus-agent` already installed in `developer-setup.sh`. No change to the libvirt/Proxmox path — worth a quick confirmation boot on those before merge, but the cidata bench above exercises exactly that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)