### PR TITLE
feat: read tunnel endpoint from /etc/glueops/tunnel_endpoint

### DIFF
--- a/developer-setup.sh
+++ b/developer-setup.sh
@@ -358,6 +358,14 @@ dev() {
     
     [ -f /etc/glueops/cde_token ] && export CDE_TOKEN=$(cat /etc/glueops/cde_token)
 
+    # Regional sish endpoint written by cloud-init on newer VMs; older VMs
+    # have no file and stay on the legacy central tunnel.
+    TUNNEL_ENDPOINT="tunnels.glueopshosted.com"
+    if [ -s /etc/glueops/tunnel_endpoint ]; then
+        _regional_endpoint="$(head -n1 /etc/glueops/tunnel_endpoint | tr -d '[:space:]')"
+        [ -n "$_regional_endpoint" ] && TUNNEL_ENDPOINT="$_regional_endpoint"
+    fi
+
     # Bootstrap the CDE once per container: cde-boot runs CDE_SETUP_SCRIPT (unset -> the
     # default `cde-init`: gh auth + repo clone + AutoGlue setup). Non-fatal, and a no-op on
     # older container images that predate cde-boot.
@@ -369,7 +377,7 @@ dev() {
     sudo docker exec $ENVFILE_ARG "$CONTAINER_NAME" bash -lc 'command -v cde-boot >/dev/null 2>&1 && cde-boot || true' || true
 
     if [ -n "$CDE_TOKEN" ]; then
-        AUTOSSH_PIDFILE="$PID_FILE" autossh -M 0 -f -N -o "ServerAliveInterval 30" -o "ServerAliveCountMax 3" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/sish_tunnel_key_id_ed25519 -p 2222 -l $HOSTNAME -R cde:80:localhost:8000 tunnels.glueopshosted.com
+        AUTOSSH_PIDFILE="$PID_FILE" autossh -M 0 -f -N -o "ServerAliveInterval 30" -o "ServerAliveCountMax 3" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/sish_tunnel_key_id_ed25519 -p 2222 -l $HOSTNAME -R cde:80:localhost:8000 "$TUNNEL_ENDPOINT"
         # Disable VS Code Workspace Trust so folders open without the "Do you trust the
         # authors…" prompt. Normally a no-op (the server is baked + shimmed at image build);
         # re-shims if a VS Code update pulled a new server. If the prompt comes back, see the

--- a/developer-setup.sh
+++ b/developer-setup.sh
@@ -366,6 +366,14 @@ dev() {
         [ -n "$_regional_endpoint" ] && TUNNEL_ENDPOINT="$_regional_endpoint"
     fi
 
+    # Legacy central sish runs --append-user-to-subdomain: bind "cde" + the
+    # SSH username -> cde-<hostname>.tunnels.glueopshosted.com. Regional
+    # instances don't; the VM binds its bare hostname so URLs are just
+    # <hostname>.<region>.tunnels.cde.glueopshosted.com. The slackbot derives
+    # the access URL from the same endpoint-value rule, so keep them in sync.
+    TUNNEL_BIND="cde"
+    [ "$TUNNEL_ENDPOINT" != "tunnels.glueopshosted.com" ] && TUNNEL_BIND="$HOSTNAME"
+
     # Bootstrap the CDE once per container: cde-boot runs CDE_SETUP_SCRIPT (unset -> the
     # default `cde-init`: gh auth + repo clone + AutoGlue setup). Non-fatal, and a no-op on
     # older container images that predate cde-boot.
@@ -377,7 +385,7 @@ dev() {
     sudo docker exec $ENVFILE_ARG "$CONTAINER_NAME" bash -lc 'command -v cde-boot >/dev/null 2>&1 && cde-boot || true' || true
 
     if [ -n "$CDE_TOKEN" ]; then
-        AUTOSSH_PIDFILE="$PID_FILE" autossh -M 0 -f -N -o "ServerAliveInterval 30" -o "ServerAliveCountMax 3" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/sish_tunnel_key_id_ed25519 -p 2222 -l $HOSTNAME -R cde:80:localhost:8000 "$TUNNEL_ENDPOINT"
+        AUTOSSH_PIDFILE="$PID_FILE" autossh -M 0 -f -N -o "ServerAliveInterval 30" -o "ServerAliveCountMax 3" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/sish_tunnel_key_id_ed25519 -p 2222 -l $HOSTNAME -R "$TUNNEL_BIND":80:localhost:8000 "$TUNNEL_ENDPOINT"
         # Disable VS Code Workspace Trust so folders open without the "Do you trust the
         # authors…" prompt. Normally a no-op (the server is baked + shimmed at image build);
         # re-shims if a VS Code update pulled a new server. If the prompt comes back, see the


### PR DESCRIPTION
## What

Makes the sish tunnel endpoint configurable per VM instead of hardcoded. `dev()` now reads `/etc/glueops/tunnel_endpoint` (written by cloud-init on newer platform deployments) and falls back to the legacy `tunnels.glueopshosted.com` when the file is absent or empty:

```bash
TUNNEL_ENDPOINT="tunnels.glueopshosted.com"
if [ -s /etc/glueops/tunnel_endpoint ]; then
    _regional_endpoint="$(head -n1 /etc/glueops/tunnel_endpoint | tr -d '[:space:]')"
    [ -n "$_regional_endpoint" ] && TUNNEL_ENDPOINT="$_regional_endpoint"
fi

TUNNEL_BIND="cde"
[ "$TUNNEL_ENDPOINT" != "tunnels.glueopshosted.com" ] && TUNNEL_BIND="$HOSTNAME"
...
autossh ... -R "$TUNNEL_BIND":80:localhost:8000 "$TUNNEL_ENDPOINT"
```

The bind name follows the same endpoint-value rule: on the legacy central endpoint the VM binds `cde` (that sish runs `--append-user-to-subdomain`, producing `cde-<hostname>.tunnels...`), while on any regional endpoint it binds its bare `$HOSTNAME`, producing `<hostname>.<region>.tunnels.cde.glueopshosted.com` — no redundant `cde-` prefix. The slackbot's `cdeAccessUrl()` derives URLs from the identical rule, so tunnel and URL can never disagree.

This is part of the regional tunnel endpoints rollout: each datacenter gets its own sish instance (`<region>.tunnels.cde.glueopshosted.com`, run WITHOUT `--append-user-to-subdomain` and with `--bind-random-subdomains=false`) so codespaces connect to the closest tunnel instead of the single central one. Companion PRs: GlueOps/provisioner (`tunnel_endpoint` region config field) and GlueOps/slackbot-developer-workspaces (endpoint resolution, VM tagging, access URLs, cloud-init file write).

## Backward compatibility

- Existing VMs run the old baked image and are untouched.
- A VM built from this image with no `/etc/glueops/tunnel_endpoint` file behaves exactly as before (central tunnel).
- The new slackbot writes the file for **every** CDE VM; the `REGIONAL_TUNNEL_MIN_IMAGE_TAG` gate controls only whether its *value* can be regional. Images below the gate get the legacy central value — which the old baked `dev()` ignores (hardcoded central) and the new `dev()` resolves to identical behavior — so there is no deploy-order hazard in either direction.

## How to upgrade

1. Merge this PR and let release-please cut a release. **Note the release tag** (e.g. `v0.155.0`).
2. That tag is the value for `REGIONAL_TUNNEL_MIN_IMAGE_TAG` in the slackbot's environment — the slackbot only assigns regional endpoints to VMs whose selected image is at/above it. Images older than this release bake a `dev()` that ignores the file, so the gate keeps their tunnels and access URLs consistent (legacy central).
3. Continue with the rollout runbook in the slackbot PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
