### PR TITLE
fix: pin sish tunnel auth to the dedicated key with IdentitiesOnly

### DIFF
--- a/developer-setup.sh
+++ b/developer-setup.sh
@@ -385,7 +385,13 @@ dev() {
     sudo docker exec $ENVFILE_ARG "$CONTAINER_NAME" bash -lc 'command -v cde-boot >/dev/null 2>&1 && cde-boot || true' || true
 
     if [ -n "$CDE_TOKEN" ]; then
-        AUTOSSH_PIDFILE="$PID_FILE" autossh -M 0 -f -N -o "ServerAliveInterval 30" -o "ServerAliveCountMax 3" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/sish_tunnel_key_id_ed25519 -p 2222 -l $HOSTNAME -R "$TUNNEL_BIND":80:localhost:8000 "$TUNNEL_ENDPOINT"
+        # IdentitiesOnly keeps a forwarded ssh-agent (present when dev is
+        # re-run from a tmux session after an SSH login) from offering its
+        # keys first: sish's TOFU auth permanently pins the first accepted
+        # key per username, so an agent key winning the first-ever connection
+        # locks the VM out once that agent is gone. It also avoids blowing
+        # the server's MaxAuthTries budget on agent keys.
+        AUTOSSH_PIDFILE="$PID_FILE" autossh -M 0 -f -N -o "ServerAliveInterval 30" -o "ServerAliveCountMax 3" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -i ~/.ssh/sish_tunnel_key_id_ed25519 -p 2222 -l $HOSTNAME -R "$TUNNEL_BIND":80:localhost:8000 "$TUNNEL_ENDPOINT"
         # Disable VS Code Workspace Trust so folders open without the "Do you trust the
         # authors…" prompt. Normally a no-op (the server is baked + shimmed at image build);
         # re-shims if a VS Code update pulled a new server. If the prompt comes back, see the


### PR DESCRIPTION
One flag on the autossh invocation: `-o IdentitiesOnly=yes`.

A sish v2.23.0 source review of the tunnel auth flow found two failure modes when it's absent (both require a forwarded ssh-agent, which appears whenever `dev` is re-run from a tmux session after an SSH login — and every `dev` run restarts autossh):

1. **Permanent silent lockout**: OpenSSH offers agent keys before `-i` file identities. sish calls the TOFU authenticator once per offered key, and the first accepted key is pinned to the username forever. If an agent key wins the VM's first-ever connection, everything works until the agent disappears (detach/reboot → systemd path) — then every reconnect is a `key mismatch` 403 and the tunnel is dead until the user's file in `sish_users/` is deleted by hand.
2. **MaxAuthTries exhaustion**: sish inherits x/crypto's default of 6 auth attempts; an agent carrying ≥5 keys gets the connection dropped before the tunnel key is ever offered, even when the TOFU registration is already correct.

`IdentitiesOnly=yes` restricts the client to exactly `~/.ssh/sish_tunnel_key_id_ed25519`, eliminating both. No behavior change for the systemd boot path (no agent there) — this hardens the interactive re-run path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ErBUiAYTosnpbF9hvUj3Dn