### PR TITLE
feat!: require a tunnel endpoint; always bind the bare hostname (legacy removal)

### DIFF
--- a/developer-setup.sh
+++ b/developer-setup.sh
@@ -379,18 +379,21 @@ dev() {
     sudo docker exec $ENVFILE_ARG "$CONTAINER_NAME" bash -lc 'command -v cde-boot >/dev/null 2>&1 && cde-boot || true' || true
 
     if [ -n "$CDE_TOKEN" ]; then
-        # Validate here, after cde-boot: a bad endpoint costs the tunnel, but
-        # the container bootstrap (gh auth, repo clone, AutoGlue) is unrelated
-        # and must still run — the VM stays reachable over the tailnet.
+        # A bad endpoint costs the tunnel and nothing else: the container
+        # bootstrap above already ran, and serve-web below still starts, so
+        # the editor stays usable over the tailnet while the public URL is
+        # dead. Loud on the console, but never a reason to withhold the IDE.
+        TUNNEL_OK=1
         if [ -z "$TUNNEL_ENDPOINT" ]; then
             gum style --padding "0 1" --foreground=196 --bold \
-                "❌ ERROR:" "/etc/glueops/tunnel_endpoint is missing or empty — this region has no tunnel endpoint configured." >&2
-            return 1
-        fi
-        if [ "$TUNNEL_ENDPOINT" = "tunnels.glueopshosted.com" ]; then
+                "❌ ERROR:" "/etc/glueops/tunnel_endpoint is missing or empty — this region has no tunnel endpoint configured." \
+                "The public CDE URL will not work; reach this VM over Tailscale instead." >&2
+            TUNNEL_OK=0
+        elif [ "$TUNNEL_ENDPOINT" = "tunnels.glueopshosted.com" ]; then
             gum style --padding "0 1" --foreground=196 --bold \
-                "❌ ERROR:" "This region still points at the retired central tunnel; it must use a regional endpoint." >&2
-            return 1
+                "❌ ERROR:" "This region still points at the retired central tunnel; it must use a regional endpoint." \
+                "The public CDE URL will not work; reach this VM over Tailscale instead." >&2
+            TUNNEL_OK=0
         fi
 
         # IdentitiesOnly keeps a forwarded ssh-agent (present when dev is
@@ -399,7 +402,7 @@ dev() {
         # key per username, so an agent key winning the first-ever connection
         # locks the VM out once that agent is gone. It also avoids blowing
         # the server's MaxAuthTries budget on agent keys.
-        AUTOSSH_PIDFILE="$PID_FILE" autossh -M 0 -f -N -o "ServerAliveInterval 30" -o "ServerAliveCountMax 3" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -i ~/.ssh/sish_tunnel_key_id_ed25519 -p 2222 -l $HOSTNAME -R "$HOSTNAME":80:localhost:8000 "$TUNNEL_ENDPOINT"
+        [ "$TUNNEL_OK" = 1 ] && AUTOSSH_PIDFILE="$PID_FILE" autossh -M 0 -f -N -o "ServerAliveInterval 30" -o "ServerAliveCountMax 3" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -i ~/.ssh/sish_tunnel_key_id_ed25519 -p 2222 -l $HOSTNAME -R "$HOSTNAME":80:localhost:8000 "$TUNNEL_ENDPOINT"
         # Disable VS Code Workspace Trust so folders open without the "Do you trust the
         # authors…" prompt. Normally a no-op (the server is baked + shimmed at image build);
         # re-shims if a VS Code update pulled a new server. If the prompt comes back, see the

--- a/developer-setup.sh
+++ b/developer-setup.sh
@@ -359,18 +359,36 @@ dev() {
     [ -f /etc/glueops/cde_token ] && export CDE_TOKEN=$(cat /etc/glueops/cde_token)
 
     # Regional sish endpoint, written by cloud-init from the region's
-    # tunnel_endpoint config. No fallback: every region declares one, and a
-    # VM with no endpoint has nowhere to tunnel, so surface it loudly instead
-    # of connecting somewhere unexpected.
+    # tunnel_endpoint config. No fallback: every region declares one, and the
+    # VM always binds its bare hostname, so a missing endpoint — or the
+    # retired central host, which prefixes the SSH username onto binds — can
+    # only produce an access URL nothing serves. Fail loudly instead.
     TUNNEL_ENDPOINT=""
     if [ -s /etc/glueops/tunnel_endpoint ]; then
         TUNNEL_ENDPOINT="$(head -n1 /etc/glueops/tunnel_endpoint | tr -d '[:space:]')"
     fi
-    if [ -n "$CDE_TOKEN" ] && [ -z "$TUNNEL_ENDPOINT" ]; then
-        gum style --padding "0 1" --foreground=196 --bold \
-            "❌ ERROR:" "/etc/glueops/tunnel_endpoint is missing or empty — this region has no tunnel endpoint configured." >&2
-        return 1
+    if [ -n "$CDE_TOKEN" ]; then
+        if [ -z "$TUNNEL_ENDPOINT" ]; then
+            gum style --padding "0 1" --foreground=196 --bold \
+                "❌ ERROR:" "/etc/glueops/tunnel_endpoint is missing or empty — this region has no tunnel endpoint configured." >&2
+            return 1
+        fi
+        if [ "$TUNNEL_ENDPOINT" = "tunnels.glueopshosted.com" ]; then
+            gum style --padding "0 1" --foreground=196 --bold \
+                "❌ ERROR:" "This region still points at the retired central tunnel; it must use a regional endpoint." >&2
+            return 1
+        fi
     fi
+
+    # Bootstrap the CDE once per container: cde-boot runs CDE_SETUP_SCRIPT (unset -> the
+    # default `cde-init`: gh auth + repo clone + AutoGlue setup). Non-fatal, and a no-op on
+    # older container images that predate cde-boot.
+    # Pass the env at EXEC time (not just the container's frozen create-time --env-file) so a
+    # later profile/secret edit reaches a forced re-run, and secrets are scoped to this exec.
+    ENVFILE_ARG=""
+    [ -f /etc/glueops/codespace.env ] && ENVFILE_ARG="--env-file /etc/glueops/codespace.env"
+    # shellcheck disable=SC2086 # ENVFILE_ARG must word-split into flag + path (or nothing)
+    sudo docker exec $ENVFILE_ARG "$CONTAINER_NAME" bash -lc 'command -v cde-boot >/dev/null 2>&1 && cde-boot || true' || true
 
     if [ -n "$CDE_TOKEN" ]; then
         # IdentitiesOnly keeps a forwarded ssh-agent (present when dev is

--- a/developer-setup.sh
+++ b/developer-setup.sh
@@ -367,18 +367,6 @@ dev() {
     if [ -s /etc/glueops/tunnel_endpoint ]; then
         TUNNEL_ENDPOINT="$(head -n1 /etc/glueops/tunnel_endpoint | tr -d '[:space:]')"
     fi
-    if [ -n "$CDE_TOKEN" ]; then
-        if [ -z "$TUNNEL_ENDPOINT" ]; then
-            gum style --padding "0 1" --foreground=196 --bold \
-                "❌ ERROR:" "/etc/glueops/tunnel_endpoint is missing or empty — this region has no tunnel endpoint configured." >&2
-            return 1
-        fi
-        if [ "$TUNNEL_ENDPOINT" = "tunnels.glueopshosted.com" ]; then
-            gum style --padding "0 1" --foreground=196 --bold \
-                "❌ ERROR:" "This region still points at the retired central tunnel; it must use a regional endpoint." >&2
-            return 1
-        fi
-    fi
 
     # Bootstrap the CDE once per container: cde-boot runs CDE_SETUP_SCRIPT (unset -> the
     # default `cde-init`: gh auth + repo clone + AutoGlue setup). Non-fatal, and a no-op on
@@ -391,6 +379,20 @@ dev() {
     sudo docker exec $ENVFILE_ARG "$CONTAINER_NAME" bash -lc 'command -v cde-boot >/dev/null 2>&1 && cde-boot || true' || true
 
     if [ -n "$CDE_TOKEN" ]; then
+        # Validate here, after cde-boot: a bad endpoint costs the tunnel, but
+        # the container bootstrap (gh auth, repo clone, AutoGlue) is unrelated
+        # and must still run — the VM stays reachable over the tailnet.
+        if [ -z "$TUNNEL_ENDPOINT" ]; then
+            gum style --padding "0 1" --foreground=196 --bold \
+                "❌ ERROR:" "/etc/glueops/tunnel_endpoint is missing or empty — this region has no tunnel endpoint configured." >&2
+            return 1
+        fi
+        if [ "$TUNNEL_ENDPOINT" = "tunnels.glueopshosted.com" ]; then
+            gum style --padding "0 1" --foreground=196 --bold \
+                "❌ ERROR:" "This region still points at the retired central tunnel; it must use a regional endpoint." >&2
+            return 1
+        fi
+
         # IdentitiesOnly keeps a forwarded ssh-agent (present when dev is
         # re-run from a tmux session after an SSH login) from offering its
         # keys first: sish's TOFU auth permanently pins the first accepted

--- a/developer-setup.sh
+++ b/developer-setup.sh
@@ -358,31 +358,19 @@ dev() {
     
     [ -f /etc/glueops/cde_token ] && export CDE_TOKEN=$(cat /etc/glueops/cde_token)
 
-    # Regional sish endpoint written by cloud-init on newer VMs; older VMs
-    # have no file and stay on the legacy central tunnel.
-    TUNNEL_ENDPOINT="tunnels.glueopshosted.com"
+    # Regional sish endpoint, written by cloud-init from the region's
+    # tunnel_endpoint config. No fallback: every region declares one, and a
+    # VM with no endpoint has nowhere to tunnel, so surface it loudly instead
+    # of connecting somewhere unexpected.
+    TUNNEL_ENDPOINT=""
     if [ -s /etc/glueops/tunnel_endpoint ]; then
-        _regional_endpoint="$(head -n1 /etc/glueops/tunnel_endpoint | tr -d '[:space:]')"
-        [ -n "$_regional_endpoint" ] && TUNNEL_ENDPOINT="$_regional_endpoint"
+        TUNNEL_ENDPOINT="$(head -n1 /etc/glueops/tunnel_endpoint | tr -d '[:space:]')"
     fi
-
-    # Legacy central sish runs --append-user-to-subdomain: bind "cde" + the
-    # SSH username -> cde-<hostname>.tunnels.glueopshosted.com. Regional
-    # instances don't; the VM binds its bare hostname so URLs are just
-    # <hostname>.<region>.tunnels.cde.glueopshosted.com. The slackbot derives
-    # the access URL from the same endpoint-value rule, so keep them in sync.
-    TUNNEL_BIND="cde"
-    [ "$TUNNEL_ENDPOINT" != "tunnels.glueopshosted.com" ] && TUNNEL_BIND="$HOSTNAME"
-
-    # Bootstrap the CDE once per container: cde-boot runs CDE_SETUP_SCRIPT (unset -> the
-    # default `cde-init`: gh auth + repo clone + AutoGlue setup). Non-fatal, and a no-op on
-    # older container images that predate cde-boot.
-    # Pass the env at EXEC time (not just the container's frozen create-time --env-file) so a
-    # later profile/secret edit reaches a forced re-run, and secrets are scoped to this exec.
-    ENVFILE_ARG=""
-    [ -f /etc/glueops/codespace.env ] && ENVFILE_ARG="--env-file /etc/glueops/codespace.env"
-    # shellcheck disable=SC2086 # ENVFILE_ARG must word-split into flag + path (or nothing)
-    sudo docker exec $ENVFILE_ARG "$CONTAINER_NAME" bash -lc 'command -v cde-boot >/dev/null 2>&1 && cde-boot || true' || true
+    if [ -n "$CDE_TOKEN" ] && [ -z "$TUNNEL_ENDPOINT" ]; then
+        gum style --padding "0 1" --foreground=196 --bold \
+            "❌ ERROR:" "/etc/glueops/tunnel_endpoint is missing or empty — this region has no tunnel endpoint configured." >&2
+        return 1
+    fi
 
     if [ -n "$CDE_TOKEN" ]; then
         # IdentitiesOnly keeps a forwarded ssh-agent (present when dev is
@@ -391,7 +379,7 @@ dev() {
         # key per username, so an agent key winning the first-ever connection
         # locks the VM out once that agent is gone. It also avoids blowing
         # the server's MaxAuthTries budget on agent keys.
-        AUTOSSH_PIDFILE="$PID_FILE" autossh -M 0 -f -N -o "ServerAliveInterval 30" -o "ServerAliveCountMax 3" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -i ~/.ssh/sish_tunnel_key_id_ed25519 -p 2222 -l $HOSTNAME -R "$TUNNEL_BIND":80:localhost:8000 "$TUNNEL_ENDPOINT"
+        AUTOSSH_PIDFILE="$PID_FILE" autossh -M 0 -f -N -o "ServerAliveInterval 30" -o "ServerAliveCountMax 3" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -i ~/.ssh/sish_tunnel_key_id_ed25519 -p 2222 -l $HOSTNAME -R "$HOSTNAME":80:localhost:8000 "$TUNNEL_ENDPOINT"
         # Disable VS Code Workspace Trust so folders open without the "Do you trust the
         # authors…" prompt. Normally a no-op (the server is baked + shimmed at image build);
         # re-shims if a VS Code update pulled a new server. If the prompt comes back, see the


### PR DESCRIPTION
**DRAFT — do not merge until the preconditions below hold.** Part of retiring the legacy central tunnel.

- The `tunnels.glueopshosted.com` default is gone: `dev()` reads `/etc/glueops/tunnel_endpoint` and, on a CDE VM, errors out if it's missing or empty instead of silently tunneling to the central host.
- The `TUNNEL_BIND` legacy branch is gone: the VM always binds its bare `$HOSTNAME`, so URLs are always `<hostname>.<region>.tunnels.cde.glueopshosted.com`.

### Preconditions
- [ ] Every region declares a `tunnel_endpoint` (companion PR: GlueOps/provisioner#236), so cloud-init always writes the file.
- [ ] The deployed slackbot writes `/etc/glueops/tunnel_endpoint` for every CDE VM — true since v4.3.0.

### Note on old images
This only affects VMs built from **this release onward**. Older images keep their baked-in `dev()` and remain safe as long as the slackbot still hands them a working endpoint — which is exactly what the slackbot's `REGIONAL_TUNNEL_MIN_IMAGE_TAG` gate governs, so retire that gate (see the slackbot PR) only once pre-v0.155.1 images are no longer offered or in use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ErBUiAYTosnpbF9hvUj3Dn